### PR TITLE
Provenance transforms

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/Provenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/Provenance.java
@@ -32,18 +32,18 @@ import java.io.Serializable;
 
 /**
  * A supertype for Provenance objects.
- *
+ * <p>
  * One day it will be sealed, currently it is only
  * extended by {@link ListProvenance}, {@link MapProvenance},
  * {@link ObjectProvenance} and {@link PrimitiveProvenance}.
- *
+ * <p>
  * Directly subclassing this will cause the serialisation mechanisms
  * for this package to throw ProvenanceException.
- *
+ * <p>
  * Provenance implementations must override {@link Object#equals},
  * {@link Object#hashCode} and {@link Object#toString} to ensure
  * correct operation.
- *
+ * <p>
  * Provenance implementations should be immutable.
  */
 public interface Provenance extends Serializable { }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/ProvenanceUtil.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/ProvenanceUtil.java
@@ -366,7 +366,7 @@ public final class ProvenanceUtil {
                 builder.append("List[\n");
                 for (Provenance provElem : listProv) {
                     builder.append(tabs);
-                    builder.append('\t');
+                    builder.append("\t\t");
                     formatProvenance(provElem,builder,tabs,depth+1);
                     builder.append('\n');
                 }
@@ -381,7 +381,7 @@ public final class ProvenanceUtil {
                 builder.append("Map{\n");
                 for (Pair<String,? extends Provenance> provElem : mapProv) {
                     builder.append(tabs);
-                    builder.append('\t');
+                    builder.append("\t\t");
                     builder.append(provElem.getA());
                     builder.append('=');
                     formatProvenance(provElem.getB(),builder,tabs,depth+1);

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The toString on a provenance can be tricky to read, but is very compact. This PR adds a few more options:
- one which converts the provenance into a String that's got newlines, tabs and spaces in it to delimit the different fields.
- one which converts the provenance into a structure of immutable Maps, Lists and Strings, representing the full toString information.

This latter form is suitable for easily converting into readable JSON.