### PR TITLE
Bumping the development version to 5.1.5-SNAPSHOT

### DIFF
--- a/README-Configuration.md
+++ b/README-Configuration.md
@@ -17,7 +17,7 @@ are performing.  Your Pipeline and its stages are represented as components
 in the configuration file.
 
 ```xml
-    <?xml version="1.0" encoding="UTF-8"?\>
+    <?xml version="1.0" encoding="UTF-8"?>
     <config>
         <component name="myPipeline" type="com.oracle.labs.sound.Pipeline">
             <property name="numThreads" value="2"/>

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,4 +1,4 @@
-jline 3.14.0
+jline 3.15.0
 
 Copyright (c) 2002-2018, the original author or authors.
 All rights reserved.
@@ -291,7 +291,7 @@ and code, are available from:
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
   THE POSSIBILITY OF SUCH DAMAGE.
 
-jackson-core, jackson-databind 2.9.9
+jackson-core, jackson-databind 2.11.2
 
 
                                  Apache License
@@ -496,7 +496,7 @@ jackson-core, jackson-databind 2.9.9
    See the License for the specific language governing permissions and
    limitations under the License.
 
-junit 5.4.2
+junit 5.6.0
 
 Copyright 2015-2020 the original author or authors.
 
@@ -599,7 +599,7 @@ If it is not possible or desirable to put the notice in a particular file, then 
 
 You may add additional accurate notices of copyright ownership.
 
-edn-java 0.5.0
+edn-java 0.7.1
 
 Copyright (c) 2012 B Smith-Mannschott -- Distributed under the Eclipse Public License
 

--- a/docs/Internals.md
+++ b/docs/Internals.md
@@ -1,0 +1,75 @@
+# Internals
+
+## Command Shell
+The command shell allows developers to implement CommandGroup, and then
+inspects the class via reflection pulling out all methods annotated @Command.
+These methods are added to a CLI, with appropriate help and arguments
+completion. The CLI is based on jline 3, but only provides the commands
+specified by the developer, along with a set of default commands that control
+how the inputs and outputs are directed, along with some help and status
+commands.
+
+The arguments for the command shell are parsed from the supplied String into
+the set of supported arguments: Strings, String arrays (if the final argument
+only), primitives, primitive boxes, and File.
+
+## Configuration System
+The configuration, options and provenance system provides ways for users to
+configure and control their programs through a combination of command line
+options and configuration files. The provenance system allows the generation of
+immutable provenance objects which record configured values and optionally
+runtime values depending on how the user implements the Provenance interface.
+
+The configuration system allows developers to mark fields @Config in classes
+which implement the Configurable interface. Those fields can have their values
+written in on construction based on the values in the configuration file, or
+presented on the command line. The supported types are primitives (and
+primitive boxes), primitive arrays, strings, string arrays, classes which
+implement Configurable, arrays of classes which implement Configurable, lists,
+sets, maps, enums, enum sets, AtomicInteger, AtomicLong, File, Path, URL,
+OffsetDateTime, LocalDate, OffsetTime, and Random (which is deprecated). The
+lists and sets accept generic parameters of any of the non-collection types,
+and Maps have String keys and accepted non-collection types as values. The
+collection types are specified as a list of values which is written into a
+concrete ArrayList, a HashSet, or a HashMap, but the annotation must be on a
+field which is typed with the List, Set or Map interface.
+
+## Lifetime of a ConfigurationManager
+
+This summarises the lifetime of a ConfigurationManager from construction until
+it goes out of scope.
+
+1. A new ConfigurationManager is constructed
+    - If it's supplied a list of file paths then those files are passed to the appropriate ConfigLoader subclass based on their file type. New subtypes can be registered by calling a static method on ConfigurationManager before instantiating it. This mechanism is how the json and edn file types are registered, the xml file type is available by default.
+    - Configuration files are processed by reading the configuration into ConfigurationData objects, which are Map<String,Union<String,List<Union<String,Class>>> for each object's configuration, along with a few metadata fields like the class name, the name given in the configuration file, and if the configuration is overlaid from some other object.
+2. Configurable objects can be supplied to the ConfigurationManager, these objects have their fields marked @Config inspected via reflection, and the values recorded in the configuration. This is performed recursively if the object contains Configurable object fields, or collections thereof.
+3. A configuration can be looked up by name or by class.
+    - If by class, each configuration which is a subclass (or the class itself) is returned as a list after they are instantiated.
+    - Configured objects are instantiated as follows:
+        1. The relevant class file is loaded, triggering static initialisers. Invalid or unknown classes trigger a PropertyException terminating instantiation.
+        2. An instance of the class is instantiated by calling it's no-args constructor, making it accessible if necessary. If this constructor is not present then a PropertyException is triggered.
+        3. Fields are initialised to their default values, as specified in the class file.
+        4. Each field from the configuration is processed, making it accessible first if necessary, triggering further object instantiation if required, writing each field value into the new object. Note: this step cannot recur infinitely as the object under construction hasn't been published yet so circular references will cause PropertyException as the object cannot be found.
+        5. Invalid field values trigger PropertyException, and the instantiation terminates without publishing the object.
+        6. After each field has been written, it's access privileges are reset to those specified in the class.
+        7. After all fields have been written then the object has it's postConfig method called. This is intended to perform object specific validation and checking, similar to a standard Java constructor. If the object is invalid it may throw PropertyException, or another RuntimeException, and the instantiated object is discarded.
+        8. Finally the object is published by storing it into the ConfigurationManager's map of instantiated objects, and then returning it to the caller.
+4. The current configuration can be written out to a file on disk, either including the just the objects that have been instantiated, or including all configurations known to the system (this may include configurations which are invalid, or for which the class is not available on the classpath).
+
+## Lifetime of a ConfigurationManager processing Options
+
+This summerises the steps executed by a `ConfigurationManager` on construction
+when parsing options.
+
+1. A class implementing Options, with fields marked @Option for values that can be read in from the command line is constructed.
+2. A new ConfigurationManager is constructed, passing in the command line argument array, along with the options subclass.
+3. The options subclass is validated and the usage statement constructed.
+    - A valid options subclass has fields which are either options subclasses, or marked @Option and the type is one of the supported configuration types mentioned above.
+    - It also requires that the charName and longName of the option fields are unique in this particular instantiation, including all fields on nested options subclasses.
+4. The arguments are checked for the "help" or "usage" arguments, and a UsageException is thrown with the usage statement.
+5. The arguments are checked for any which specify a config file format (i.e. a fully qualified class name which implements FileFormatFactory), the format factories are instantiated by calling their no-args constructor and passed to the ConfigurationManager's addFileFormatFactory method.
+6. The arguments are checked for the configuration file list argument, and any files found are processed by the appropriate ConfigLoader subclass.
+7. The arguments are checked for arguments starting "--@" and the resulting "<object-name>.<field-name> <value>" tuples are written into the configuration, overwriting or adding to what was loaded from the configuration files.
+8. All arguments which match a charName or longName in the supplied options instance (and any nested options instances) have their values parsed (using the same logic as the configuration system), and assigned to the marked field. This can trigger object instantiation from the configuration, any fields which are subtypes of Configurable or collections of Configurable treat the supplied value as a configurable object name and look it up in the configuration.
+9. All remaining unparsed arguments are stored in a String array for inspection from the ConfigurationManager
+10. The ConfigurationManager constructor returns.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,0 +1,69 @@
+# Security Considerations
+
+OLCUT is a library which performs dependency injection, configuration, command
+line arguments processing, and includes a full interactive CLI. However all of
+these mechanisms are under the control of the developer incorporating OLCUT
+into their system. For the command shell, it's important to prevent
+unauthorised users from executing any command shells present in a program. For
+the configuration system it's important to use the most specific types possible
+for configurable fields, as this reduces the scope values that a malicious
+configuration file could insert into a program, and to properly validate field
+values in the `Configurable` subclass's `postConfig` method (as you would in a
+normal constructor).
+
+The configuration system is designed to prevent cyclic references, as objects
+are only published once they have been fully constructed and their `postConfig`
+methods have executed. It should be impossible to see a half constructed object
+in any place other than that object's own `postConfig` method. If you find a
+way, please raise an issue using the appropriate channels.
+
+## Serialized files
+
+OLCUT allows the loading of Java serialized objects as specified in the
+configuration files.  Due to the inherent issues with Java serialization, these
+object files should be stored in trusted locations where third parties do not
+have access.  We recommend at minimum using a [JEP
+290](https://openjdk.java.net/jeps/290) allowlist to prevent users from
+deserializing arbitrary code, as OLCUT targets Java 8 and this is an API level
+feature in Java 9+ onwards, we recommend using a process level allowlist
+specified at JVM startup time. When OLCUT migrates to a newer Java version, we
+will include API support for specifying the allowlist in a configuration file.
+
+## Threat model
+
+As a library incorporated into other programs, OLCUT expects it's inputs to be
+checked by the wider program, and to have the locations it reads from
+controlled appropriately.  Below we discuss a few threats specific to how OLCUT
+operates.
+
+| Threat name                  | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Exposed assets              | Mitigations                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Malicious configuration file | Configuration files can contain arbitrarily large trees, and could cause DOS issues. Alternatively the configuration files could be arbitrarily large and cause DOS issues when being read.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None                        | The developer controls which fields are configurable, and should ensure that the configurable structure is always bounded by not allowing arbitrary recursion in configurable fields. Additionally OLCUT's config storage format is flat, and will not allow circular references between configured objects. To mitigate the large config file issue we could limit the file size that is allowed to be read, though this is trickier when loading configuration from jar files. |
+| Configuration saving         | Configuration files can be generated from the state of existing configurable objects (under developer control). This program state could potentially include sensitive information.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Sensitive program state     | Do not mark fields @Config if they could contain sensitive information. Alternatively if it is critical they be configurable for the program to operate, then mark them @Config(redact=true), which will prevent the sensitive fields from being written out in configuration or provenance. Finally if the information must be saved, then ensure that the file is written to secure storage.                                                                                   |
+| Provenance capture           | Provenance tracks the state and construction path of objects by inspecting their fields. Each provenance object is either implemented by the developer, or autogenerated from a configurable object. If the object state contains sensitive information this will persist in the provenance.                                                                                                                                                                                                                                                                                                                                                                   | Sensitive program state     | The mitigations for configuration saving apply, along with an additional one which is to not store sensitive non-configurable fields in the provenance object implemented by the developer.                                                                                                                                                                                                                                                                                      |
+| Imprecise Config annotations | The @Config annotation can be applied to a range of Java primitives and immutable classes, along with things which implement Configurable. If the developer designs a class hierarchy where the configurable fields have relaxed type boundaries (i.e. the field is of type Configurable rather than the specific type Foo) then it allows malicious configuration files to inject any other class that implements Configurable that is available on the class path. This could result in an invalid program state if not properly checked, and potentially result in unexpected behaviour as the postConfig methods are executed on the Configurable objects. | Program state and execution | @Config and @Option annotations should use the most specific field type available to them. postConfig methods should properly validate their arguments like constructors do, and be written defensively wrt to odd inputs.                                                                                                                                                                                                                                                       |
+
+## Java Security Manager
+
+The configuration and provenance systems use reflection to construct and
+inspect classes, as such when running with a Java security manager you need to
+give the olcut jar appropriate permissions. We have tested this set of
+permissions which allows the configuration and provenance systems to work:
+
+```
+    // OLCUT permissions
+    grant codeBase "file:/path/to/olcut/olcut-core.jar" {
+            permission java.lang.RuntimePermission "accessDeclaredMembers";
+            permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+            permission java.util.logging.LoggingPermission "control";
+            permission java.io.FilePermission "<<ALL FILES>>", "read";
+            permission java.util.PropertyPermission "*", "read,write";
+    };
+```
+
+The read FilePermission can be restricted to the jars which contain
+configuration files, configuration files on disk, and the locations of
+serialised objects. The one here provides access to the complete filesystem, as
+the necessary read locations are program specific. If you need to save an OLCUT
+configuration out then you will also need to add write permissions for the save
+location. 

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandGroup.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandGroup.java
@@ -30,7 +30,7 @@ package com.oracle.labs.mlrg.olcut.command;
 
 /**
  * Essentially a marker interface for any class that provides
- * @Command commands for a command interpreter.  Also provides a
+ * {@code @Command} commands for a command interpreter.  Also provides a
  * little helpful meta-data.
  */
 public interface CommandGroup {

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurableMXBean.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurableMXBean.java
@@ -74,6 +74,9 @@ public interface ConfigurableMXBean {
 
     /**
      * Sets the values in a property list.
+     * @param property the property whose value we want to set
+     * @param values the value that the property should be set to.
+     * @return True if the values were set correctly.
      */
     public boolean setValues(String property, String[] values);
 

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/util/StopWatch.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/util/StopWatch.java
@@ -145,7 +145,7 @@ public class StopWatch implements Serializable {
     /**
      * Gets the average time per click (start/stop)
      * @deprecated Ambiguous units, use unit-specific get methods instead. Behavior of this method is undefined in subclasses.
-     * @return
+     * @return The average time.
      */
     public double getAvgTime() {
         return getTime() / (double) clicks;
@@ -239,13 +239,14 @@ public class StopWatch implements Serializable {
                 TimeUnit.MILLISECONDS.toHours(millis) % TimeUnit.DAYS.toHours(1),
                 TimeUnit.MILLISECONDS.toMinutes(millis) % TimeUnit.HOURS.toMinutes(1),
                 TimeUnit.MILLISECONDS.toSeconds(millis) % TimeUnit.MINUTES.toSeconds(1),
-                TimeUnit.MILLISECONDS.toMillis(millis) % TimeUnit.SECONDS.toMillis(1));    }
+                TimeUnit.MILLISECONDS.toMillis(millis) % TimeUnit.SECONDS.toMillis(1));
+    }
 
     /**
      * Creates a string representation to the nearest largest appropriate time unit.
      * @deprecated Use toString() instead which gives a more accurate, but still scoped appropriately time string
-     * @param millis
-     * @return
+     * @param millis The time to convert to String.
+     * @return A String representation.
      */
     @Deprecated
     public static String toTimeString(double millis) {

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <version>${revision}</version>
     <packaging>pom</packaging>
     <properties>
-        <revision>5.1.4</revision>
+        <revision>5.1.5-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -294,6 +294,21 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.0.0-M1</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.9.1</version>
+            </plugin>
         </plugins>
     </build>
+          <reporting>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.0.4</version>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
Bump the dev version, add a couple of reporting plugins to the pom file, fix some javadoc issues and add some more markdown docs for the internals and security considerations.