### PR TITLE
CommandInterpreter runs the default command when exiting, which can lead to exceptions

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandInterpreter.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandInterpreter.java
@@ -838,7 +838,7 @@ public class CommandInterpreter extends Thread {
                     ex.printStackTrace(out);
                 }
             } else {
-                if(first && defaultCommand != null) {
+                if(first && defaultCommand != null && !command.equals("on_exit")) {
                     String[] newArgs = new String[args.length + 1];
                     newArgs[0] = defaultCommand;
                     System.arraycopy(args, 0, newArgs, 1,


### PR DESCRIPTION
If a CommandInterpreter defines a default command, then when the CI is exiting, as part of it's cleanup it runs the "on_exit" command. If no on_exit command is defined, then the default command was inadvertently run at close time. This can very easily lead to exceptions being reported during the close process.

Fix is just to check if the unknown command is "on_exit" before running the default command.