### PR TITLE
Give clearer errors when there are access problems with Options classes

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/Options.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/Options.java
@@ -30,6 +30,7 @@ package com.oracle.labs.mlrg.olcut.config;
 
 import com.oracle.labs.mlrg.olcut.util.Pair;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -154,8 +155,21 @@ public interface Options {
                 list.addAll(optionsList);
 
                 return list;
-            } catch (IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
-                throw new ArgumentException(e,"Could not instantiate Options class " + options.getName() +", it has no default constructor.");
+            } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+                throw new ArgumentException(e,"Could not instantiate Options class " + options.getName() + ", it has no default constructor.");
+            } catch (IllegalAccessException e) {
+                if (!Modifier.isPublic(options.getModifiers())) {
+                    throw new ArgumentException(e,"Could not instantiate Options class " + options.getName() + ", it must be public.");
+                }
+                try {
+                    Constructor constructor = options.getDeclaredConstructor();
+                    if (!Modifier.isPublic(constructor.getModifiers())) {
+                        throw new ArgumentException(e,"Could not instantiate Options class " + options.getName() + ", its default constructor must be public.");
+                    }
+                } catch (NoSuchMethodException nsme) {
+                    throw new ArgumentException(e,"Could not instantiate Options class " + options.getName() + ", it has no default constructor.");
+                }
+                throw new ArgumentException(e,"Could not instantiate Options class " + options.getName());
             }
 
         }

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
@@ -36,8 +36,9 @@ import java.util.List;
 import java.util.Random;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionsTest {
 
@@ -98,6 +99,41 @@ public class OptionsTest {
         assertEquals(',', options.myChars[1]);
         assertEquals('b', options.myChars[2]);
         assertEquals('c', options.myChars[3]);
+    }
+
+    private static class PrivateClassOptions implements Options {
+        @Option(charName='s',longName="something",usage="Provide something")
+        public String s;
+    }
+
+    public static class PrivateConstructorOptions implements Options {
+        private PrivateConstructorOptions() {
+        }
+
+        @Option(charName='s',longName="something",usage="Provide something")
+        public String s;
+    }
+
+    @Test
+    public void testAccess() {
+        PrivateClassOptions one = new PrivateClassOptions();
+	    Exception e = assertThrows(ArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                ConfigurationManager cm = new ConfigurationManager(new String[]{"-s", "donkey"}, one);
+            }
+        });
+	    assertTrue(e.getMessage().contains("must be public"));
+
+	    PrivateConstructorOptions two = new PrivateConstructorOptions();
+	    Exception ex = assertThrows(ArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                ConfigurationManager cm = new ConfigurationManager(new String[]{"-s", "donkey"}, two);
+            }
+        });
+        assertTrue(ex.getMessage().contains("default constructor must be public"));
+
     }
 }
 

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
@@ -42,18 +42,18 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionsTest {
 
-	@Test
-	public void testBasic() {
-		String[] args = new String[] {"--deeper-string","How low can you go?",
-				"--deep-string", "double bass",
-				"--enum", "THINGS", 
-				"--output-string", "ringstay putoutay",
-				"--seed", "42",
-				"--baz", "X,Y,Z",
-				"--output-file", "/tmp/output.txt",
-				"--input-file", "/tmp/input.txt",
-				"--pi", "3.1415927"};
-		TestOptions options = new TestOptions();
+@Test
+    public void testBasic() {
+        String[] args = new String[] {"--deeper-string","How low can you go?",
+                "--deep-string", "double bass",
+                "--enum", "THINGS", 
+                "--output-string", "ringstay putoutay",
+                "--seed", "42",
+                "--baz", "X,Y,Z",
+                "--output-file", "/tmp/output.txt",
+                "--input-file", "/tmp/input.txt",
+                "--pi", "3.1415927"};
+        TestOptions options = new TestOptions();
         ConfigurationManager cm = new ConfigurationManager(args,options);
         
         assertEquals(3.1415927d, options.pi, 0.00001);
@@ -70,18 +70,18 @@ public class OptionsTest {
         String[] unparsedArgs = cm.getUnnamedArguments();
         assertEquals(0, unparsedArgs.length);
 
-	}
-	
-	@Test
-	public void testBackSlash() {
+    }
+    
+    @Test
+    public void testBackSlash() {
         String deeperStringValue = ConfigurationManager.IS_WINDOWS ? "\\s+" : "\\\\s+";
-		String[] args = new String[] {"--deeper-string", deeperStringValue};
-		TestOptions options = new TestOptions();
+        String[] args = new String[] {"--deeper-string", deeperStringValue};
+        TestOptions options = new TestOptions();
         ConfigurationManager cm = new ConfigurationManager(args,options);
         assertEquals("\\s+", options.bar.deepOptions.deeperOptions.deeperString);
         cm.close();
         
-	}
+    }
 
     public static class CommaOptions implements Options {
         @Option(longName="my-chars",usage="The characters.")
@@ -115,7 +115,7 @@ public class OptionsTest {
     }
 
     public static class NoDefaultConstructorOptions implements Options {
-	    public NoDefaultConstructorOptions(String aValue) {
+        public NoDefaultConstructorOptions(String aValue) {
         }
 
         @Option(charName='s',longName="something",usage="Provide something")
@@ -125,16 +125,16 @@ public class OptionsTest {
     @Test
     public void testAccess() {
         PrivateClassOptions one = new PrivateClassOptions();
-	    Exception e = assertThrows(ArgumentException.class, new Executable() {
+        Exception e = assertThrows(ArgumentException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ConfigurationManager cm = new ConfigurationManager(new String[]{"-s", "donkey"}, one);
             }
         });
-	    assertTrue(e.getMessage().contains("must be public"));
+        assertTrue(e.getMessage().contains("must be public"));
 
-	    PrivateConstructorOptions two = new PrivateConstructorOptions();
-	    e = assertThrows(ArgumentException.class, new Executable() {
+        PrivateConstructorOptions two = new PrivateConstructorOptions();
+        e = assertThrows(ArgumentException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ConfigurationManager cm = new ConfigurationManager(new String[]{"-s", "donkey"}, two);

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
@@ -114,6 +114,14 @@ public class OptionsTest {
         public String s;
     }
 
+    public static class NoDefaultConstructorOptions implements Options {
+	    public NoDefaultConstructorOptions(String aValue) {
+        }
+
+        @Option(charName='s',longName="something",usage="Provide something")
+        public String s;
+    }
+
     @Test
     public void testAccess() {
         PrivateClassOptions one = new PrivateClassOptions();
@@ -126,13 +134,22 @@ public class OptionsTest {
 	    assertTrue(e.getMessage().contains("must be public"));
 
 	    PrivateConstructorOptions two = new PrivateConstructorOptions();
-	    Exception ex = assertThrows(ArgumentException.class, new Executable() {
+	    e = assertThrows(ArgumentException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ConfigurationManager cm = new ConfigurationManager(new String[]{"-s", "donkey"}, two);
             }
         });
-        assertTrue(ex.getMessage().contains("default constructor must be public"));
+        assertTrue(e.getMessage().contains("default constructor must be public"));
+
+        NoDefaultConstructorOptions three = new NoDefaultConstructorOptions("donkey");
+        e = assertThrows(ArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                ConfigurationManager cm = new ConfigurationManager(new String[]{"-s", "donkey"}, three);
+            }
+        });
+        assertTrue(e.getMessage().contains("no default constructor"));
 
     }
 }


### PR DESCRIPTION
Added a little extra error checking when we fail to instantiate an Options class to account for access errors with the constructor or the class as well as if the constructor is missing so that we can give a more accurate error message. Added tests to check behavior.