### PR TITLE
Fixing ProvenanceUtil.extractConfiguration so NullConfiguredProvnances don't leak into ConfigurationData

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/NullConfiguredProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/NullConfiguredProvenance.java
@@ -56,6 +56,10 @@ public final class NullConfiguredProvenance implements ConfiguredObjectProvenanc
         this.className = className;
     }
 
+    /**
+     * Used to unmarshal a null provenance.
+     * @param map The set of fields. Must only contain the class name the provenance came from.
+     */
     public NullConfiguredProvenance(Map<String,Provenance> map) {
         if (map.containsKey(ObjectProvenance.CLASS_NAME)) {
             this.className = map.get(ObjectProvenance.CLASS_NAME).toString();

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/ExampleProvenancableConfigurable.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/ExampleProvenancableConfigurable.java
@@ -31,7 +31,6 @@ package com.oracle.labs.mlrg.olcut.provenance;
 import com.oracle.labs.mlrg.olcut.config.Config;
 import com.oracle.labs.mlrg.olcut.config.Configurable;
 import com.oracle.labs.mlrg.olcut.provenance.ExampleProvenancableConfigurable.ExampleProvenance;
-import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.primitives.DoubleProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.primitives.IntProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.primitives.StringProvenance;

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/ProvenanceUtilTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/ProvenanceUtilTest.java
@@ -1,15 +1,22 @@
 package com.oracle.labs.mlrg.olcut.provenance;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.oracle.labs.mlrg.olcut.config.ConfigurationData;
+import com.oracle.labs.mlrg.olcut.provenance.impl.NullConfiguredProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +34,29 @@ public class ProvenanceUtilTest {
     }
 
     @Test
-    void testSerialize() throws Exception {
+    public void testNullFields() {
+        TestProvenancableConfigurable test = new TestProvenancableConfigurable(25, Arrays.asList(5,4,3,2,1));
+
+        ConfiguredObjectProvenance prov = test.getProvenance();
+
+        assertTrue(prov.getConfiguredParameters().get("nullField") instanceof NullConfiguredProvenance);
+
+        List<ConfigurationData> configList = ProvenanceUtil.extractConfiguration(prov);
+
+        // The NullConfiguredProvenance should be an empty field in the configuration object that holds it so there is
+        // only a single object provenance to convert into configuration data.
+        assertEquals(1,configList.size());
+
+        List<ObjectMarshalledProvenance> marshalledProvenances = ProvenanceUtil.marshalProvenance(prov);
+        assertEquals(2,marshalledProvenances.size());
+
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(marshalledProvenances);
+
+        assertEquals(prov,unmarshalledProvenance);
+    }
+
+    @Test
+    public void testSerialize() throws Exception {
         File tempFile = File.createTempFile("serialized-provenancable", ".ser", new File("target"));
         tempFile.deleteOnExit();
 

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/TestProvenancableConfigurable.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/TestProvenancableConfigurable.java
@@ -1,0 +1,52 @@
+package com.oracle.labs.mlrg.olcut.provenance;
+
+import com.oracle.labs.mlrg.olcut.config.Config;
+import com.oracle.labs.mlrg.olcut.config.Configurable;
+import com.oracle.labs.mlrg.olcut.provenance.impl.ConfiguredObjectProvenanceImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Test class for provenance null handling.
+ */
+public final class TestProvenancableConfigurable implements Configurable, Provenancable<ConfiguredObjectProvenance> {
+
+    // This field is always null to test the extraction of null fields.
+    @Config
+    public ExampleProvenancableConfigurable nullField = null;
+
+    @Config
+    public int someIntValue = 5;
+
+    @Config
+    public List<Integer> someListOfInts = new ArrayList<>();
+
+    public TestProvenancableConfigurable() {}
+
+    public TestProvenancableConfigurable(int intValue, List<Integer> listOfInts) {
+        someIntValue = intValue;
+        someListOfInts = new ArrayList<>(listOfInts);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestProvenancableConfigurable that = (TestProvenancableConfigurable) o;
+        return someIntValue == that.someIntValue &&
+                Objects.equals(nullField, that.nullField) &&
+                someListOfInts.equals(that.someListOfInts);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nullField, someIntValue, someListOfInts);
+    }
+
+    @Override
+    public ConfiguredObjectProvenance getProvenance() {
+        return new ConfiguredObjectProvenanceImpl(this,"test-configurable-provenancable");
+    }
+}


### PR DESCRIPTION
ConfigurationData isn't supposed to have any null fields, and automatically extracting provenance from an object with null fields inserts `NullConfiguredProvenance` to ensure that it records all the (provenancable) fields. This PR links up the two bits to ensure that converting a provenance into a configuration gives a valid configuration. Previously the NullConfiguredProvenance would show up as an empty reference to a configurable type, which works if the configurable type is a class (without mandatory fields) but fails if the field type is an interface as the interface isn't constructable.