### PR TITLE
Adding the enum constants to the type displayed for an EnumSet Option in the usage String

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/DescribeConfigurable.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/DescribeConfigurable.java
@@ -203,7 +203,7 @@ public class DescribeConfigurable {
                                 Object[] constants = listType.getEnumConstants();
                                 List<String> enumConstants = new ArrayList<>();
                                 for (Object o : constants) {
-                                    enumConstants.add(((Enum)o).name());
+                                    enumConstants.add(((Enum<?>)o).name());
                                 }
                                 fi = new FieldInfo(f.getName(),f.getType().getName(),f,configAnnotation,defaultVal,listType.getCanonicalName(),enumConstants);
                             } else {

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/OptionsTest.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 
@@ -42,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class OptionsTest {
 
-@Test
+    @Test
     public void testBasic() {
         String[] args = new String[] {"--deeper-string","How low can you go?",
                 "--deep-string", "double bass",
@@ -152,6 +153,22 @@ public class OptionsTest {
         assertTrue(e.getMessage().contains("no default constructor"));
 
     }
+
+    @Test
+    public void enumSetUsage() {
+        EnumSetOptions opts = new EnumSetOptions();
+
+        String[] args = new String[]{"--enum-set", "THINGS,STUFF"};
+
+        ConfigurationManager cm = new ConfigurationManager(args, opts);
+
+        EnumSet<OptionsEnum> enumSet = EnumSet.of(OptionsEnum.THINGS, OptionsEnum.STUFF);
+        assertEquals(opts.enumSet,enumSet);
+
+        String usage = cm.usage();
+
+        assertTrue(usage.contains("EnumSet - {THINGS, STUFF, OTHER_THINGS}"));
+    }
 }
 
 class TestOptions implements Options {
@@ -248,6 +265,20 @@ class DeeperOptions implements Options {
     @Override
     public String toString() {
         return "deeperString="+deeperString;
+    }
+}
+
+class EnumSetOptions implements Options {
+    @Override
+    public String getOptionsDescription() {
+        return "It's got an enumset.";
+    }
+    @Option(charName='e', longName="enum-set", usage="It's an enum set")
+    public EnumSet<OptionsEnum> enumSet;
+
+    @Override
+    public String toString() {
+        return "enumSet="+enumSet.toString();
     }
 }
 


### PR DESCRIPTION
Enums currently display the enum constants in any usage string, and in `DescribeConfigurable` both enum and EnumSet fields display the enum constants. This PR fixes the usage string generation so that it displays the enum constants for EnumSet option fields. I also added Javadoc to the rest of the methods in `Options`.