### PR TITLE
Fix for importing system properties into GlobalProperties

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/property/ImmutableGlobalProperties.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/property/ImmutableGlobalProperties.java
@@ -31,6 +31,7 @@ package com.oracle.labs.mlrg.olcut.config.property;
 import com.oracle.labs.mlrg.olcut.config.PropertyException;
 import com.oracle.labs.mlrg.olcut.util.Util;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -40,24 +41,37 @@ import java.util.regex.Matcher;
 
 /**
  * A collection of GlobalProperties which can't be mutated.
+ * <p>
+ * In addition to the set properties, it also includes
+ * preset properties. This set currently includes {@link #HOSTNAME}
+ * which lazily resolves to the system hostname.
  */
 public class ImmutableGlobalProperties implements Iterable<Map.Entry<String,GlobalProperty>> {
+
+    public static final String HOSTNAME = "gp.hostName";
 
     /**
      * A set of distinguished properties that we would like to have.
      */
-    private static Map<String, GlobalProperty> distinguished = new HashMap<>();
+    private static final Map<String, GlobalProperty> distinguished = new HashMap<>();
 
     protected final HashMap<String, GlobalProperty> map;
 
     static {
-        distinguished.put("gp.hostName", new LazyGlobalProperty(Util::getHostName));
+        distinguished.put(HOSTNAME, new LazyGlobalProperty(Util::getHostName));
     }
 
+    /**
+     * Creates an ImmutableGlobalProperties.
+     */
     public ImmutableGlobalProperties() {
         this.map = new HashMap<>();
     }
 
+    /**
+     * Creates an ImmutableGlobalProperties copy of the other properties.
+     * @param globalProperties The properties to copy.
+     */
     public ImmutableGlobalProperties(GlobalProperties globalProperties) {
         this.map = new HashMap<>();
         for(String key : globalProperties.map.keySet()) {
@@ -65,10 +79,20 @@ public class ImmutableGlobalProperties implements Iterable<Map.Entry<String,Glob
         }
     }
 
+    /**
+     * Creates an ImmutableGlobalProperties view of this map.
+     * @param map The map to wrap.
+     */
     private ImmutableGlobalProperties(HashMap<String, GlobalProperty> map) {
         this.map = map;
     }
 
+    /**
+     * Returns the GlobalProperty associated with the name, or
+     * null if there is no such property.
+     * @param propertyName The property name.
+     * @return The GlobalProperty if found, or null.
+     */
     public GlobalProperty get(String propertyName) {
         GlobalProperty gp = map.get(propertyName);
         if(gp == null) {
@@ -127,10 +151,20 @@ public class ImmutableGlobalProperties implements Iterable<Map.Entry<String,Glob
         }
     }
 
+    /**
+     * Returns a view over the property names.
+     * @return The set of property names.
+     */
     public Set<String> keySet() {
-        return map.keySet();
+        return Collections.unmodifiableSet(map.keySet());
     }
 
+    /**
+     * Returns an unmodifiable view of this GlobalProperties.
+     * <p>
+     * Changes in the underlying properties are reflected in this view.
+     * @return An unmodifiable view of the properties.
+     */
     public ImmutableGlobalProperties getImmutableProperties() {
         return new ImmutableGlobalProperties(map);
     }

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/GlobalPropertyTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/GlobalPropertyTest.java
@@ -30,7 +30,6 @@ package com.oracle.labs.mlrg.olcut.config;
 
 import com.oracle.labs.mlrg.olcut.config.io.ConfigLoaderException;
 import com.oracle.labs.mlrg.olcut.util.Util;
-import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/property/GlobalPropertiesTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/property/GlobalPropertiesTest.java
@@ -1,0 +1,25 @@
+package com.oracle.labs.mlrg.olcut.config.property;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class GlobalPropertiesTest {
+
+    @Test
+    public void strangeSystemProperties() {
+        Properties sysProps = new Properties();
+        sysProps.setProperty("this property has spaces spaces are bad","some-value");
+        sysProps.setProperty("this property has weird punctuation !@#$%^&&*","another-value");
+        sysProps.setProperty("this.property.conforms.to.the.global.props.regex","also-a-value");
+
+        GlobalProperties gp = new GlobalProperties();
+        gp.importProperties(sysProps);
+        assertNull(gp.get("this property has spaces spaces are bad"));
+        assertNull(gp.get("this property has weird punctuation !@#$%^&&*"));
+        assertEquals(new GlobalProperty("also-a-value"),gp.get("this.property.conforms.to.the.global.props.regex"));
+    }
+}


### PR DESCRIPTION
The GlobalProperties class throws an exception when importing system properties if they don't map to the global property regex. Properties which don't fit this regex can't be used as global properties for replacing things so shouldn't be in there anyway. This patch fixes that, adds more javadoc to the surrounding classes, and adds a test for the behaviour.