### PR TITLE
Fix for importing configurables with null fields

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
@@ -2018,6 +2018,14 @@ public class ConfigurationManager implements Closeable {
                     propertyName = field.getName();
                     Class<?> fieldClass = field.getType();
                     if (!configAnnotation.redact()) {
+                        if (field.get(configurable) == null) {
+                            if (configAnnotation.mandatory()) {
+                                throw new PropertyException(name,field.getName(),"Expected to extract a value from mandatory field, but found null");
+                            } else {
+                                // skip null fields, we can't extract configuration from them
+                                continue;
+                            }
+                        }
                         FieldType ft = FieldType.getFieldType(fieldClass);
                         List<Class<?>> genericList = PropertySheet.getGenericClass(field);
                         Class<?> genericType = Object.class;

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/ImportConfigTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/ImportConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *
@@ -34,9 +34,12 @@ import org.junit.jupiter.api.Test;
 
 import static com.oracle.labs.mlrg.olcut.util.IOUtil.replaceBackSlashes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 
 /**
@@ -160,7 +163,7 @@ public class ImportConfigTest {
         StringListConfigurable sl2 = (StringListConfigurable) cm1.lookup(
                 "listTest");
 
-        for(int i = 0; i < sl1.strings.size(); i++) {
+        for (int i = 0; i < sl1.strings.size(); i++) {
             assertEquals(sl1.strings.get(i), sl2.strings.get(i));
         }
     }
@@ -208,7 +211,7 @@ public class ImportConfigTest {
         assertEquals(l1.c.c.c.s, l1n.c.c.c.s);
         assertEquals(l1.c.c.c.i, l1n.c.c.c.i);
         assertEquals(l1.c.c.c.d, l1n.c.c.c.d, 0.001);
-     }
+    }
 
     @Test
     public void importMultiEmbeddedComponentList() throws IOException {
@@ -237,6 +240,30 @@ public class ImportConfigTest {
         assertEquals(l1.c.c.c.s, l1n.c.c.c.s);
         assertEquals(l1.c.c.c.i, l1n.c.c.c.i);
         assertEquals(l1.c.c.c.d, l1n.c.c.c.d, 0.001);
-     }
-    
+    }
+
+    @Test
+    public void testNullImport() {
+        ConfigurationManager cm = new ConfigurationManager();
+
+        // Test import when mandatory field is non-null
+        ListConfig l = new ListConfig();
+        l.doubleList = Arrays.asList(1.0,2.0,3.0);
+        l.stringList = null;
+        l.stringConfigurableList = null;
+
+        cm.importConfigurable(l,"list-config");
+        ListConfig newL = (ListConfig) cm.lookup("list-config");
+        assertEquals(l.doubleList, newL.doubleList);
+        assertNull(newL.stringList);
+        assertNull(newL.stringConfigurableList);
+
+        // Test import when mandatory field is null, should throw
+        ListConfig nullMandatory = new ListConfig();
+        nullMandatory.doubleList = null;
+        nullMandatory.stringConfigurableList = null;
+        nullMandatory.stringList = Arrays.asList("foo","bar","baz","quux");
+
+        assertThrows(PropertyException.class,() -> cm.importConfigurable(nullMandatory,"null-list-config"));
+    }
 }

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/ListConfig.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/ListConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *
@@ -35,13 +35,13 @@ import java.util.List;
  */
 public class ListConfig implements Configurable {
 
-    @Config
+    @Config(mandatory=false)
     public List<String> stringList;
 
-    @Config
+    @Config(mandatory=true)
     public List<Double> doubleList;
 
-    @Config
+    @Config(mandatory=false)
     public List<StringConfigurable> stringConfigurableList;
 
     @Override


### PR DESCRIPTION
`ConfigurationManager.importConfigurable` throws when it inspects an object with a null valued configurable field. `null` fields are fine if the `@Config` annotation does not have `mandatory = true`, and this patch updates the import logic to allow that, along with adding a specific exception thrown if a mandatory field is null. It also adds a test for this behaviour.