### PR TITLE
Fixing MutableNumber.copyMap so it preserves iteration order

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
@@ -1247,7 +1247,7 @@ public class ConfigurationManager implements Closeable {
     public Set<String> getInstanceNames(Class<? extends Configurable> type) {
         Set<String> instanceNames = new HashSet<>();
 
-        for (PropertySheet ps : symbolTable.values()) {
+        for (PropertySheet<?> ps : symbolTable.values()) {
             if (!ps.isInstantiated()) {
                 continue;
             }
@@ -1279,7 +1279,7 @@ public class ConfigurationManager implements Closeable {
      * with that name does not occur in the configuration.
      */
     public Object lookupSerializedObject(String objectName) {
-        SerializedObject so = serializedObjects.get(objectName);
+        SerializedObject<?> so = serializedObjects.get(objectName);
         if(so == null) {
             return null;
         }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/util/MutableNumber.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/util/MutableNumber.java
@@ -29,7 +29,9 @@
 package com.oracle.labs.mlrg.olcut.util;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.SortedMap;
 
 /**
  * The base class for the mutable primitive boxes in OLCUT.
@@ -46,14 +48,23 @@ public abstract class MutableNumber extends Number {
      * Copies a map which contains mutable number values.
      * <p>
      * Used to duplicate maps which count things ensuring that they don't
-     * double count values. The keys are *not* copied.
+     * double count values. The keys are *not* copied. Preserves the iteration
+     * order of {@link SortedMap} and {@link LinkedHashMap} by returning {@link LinkedHashMap}
+     * otherwise returns {@link HashMap}.
      * @param input The map to copy.
      * @param <T> The key type.
      * @param <U> The value type.
      * @return A copy of the map with copied values.
      */
     public static <T,U extends MutableNumber> Map<T,U> copyMap(Map<T,U> input) {
-        HashMap<T,U> output = new HashMap<>();
+        Map<T,U> output;
+
+        // If the map has an iteration order then preserve it.
+        if ((input instanceof SortedMap) || (input instanceof LinkedHashMap)) {
+            output = new LinkedHashMap<>();
+        } else {
+            output = new HashMap<>();
+        }
 
         for (Map.Entry<T,U> e : input.entrySet()) {
             @SuppressWarnings("unchecked") //copy returns the same type.


### PR DESCRIPTION
There's a bug in Tribuo's multidimensional regression because it assumed `MutableNumber.copyMap` was preserving iteration order. There are a number of fixes for Tribuo coming as this issue exposed several places where the proper validation wasn't being applied, but this PR modifies `copyMap` so it preserves iteration order.