### PR TITLE
Adds XML serialization and deserialization support for MarshalledProvenances

### DIFF
--- a/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceMarshaller.java
+++ b/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceMarshaller.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the 2-clause BSD license.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.labs.mlrg.olcut.config.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.oracle.labs.mlrg.olcut.provenance.io.MarshalledProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceMarshaller;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class for serializing and deserializing provenances to/from json.
+ */
+public final class JsonProvenanceMarshaller implements ProvenanceMarshaller {
+
+    private static final TypeReference<List<MarshalledProvenance>> typeRef = new TypeReference<List<MarshalledProvenance>>() {};
+
+    private final ObjectMapper mapper;
+
+    /**
+     * Construct a JsonProvenanceMarshaller.
+     *
+     * @param indentOutput Indent the output.
+     */
+    public JsonProvenanceMarshaller(boolean indentOutput) {
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JsonProvenanceModule());
+        if (indentOutput) {
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        }
+    }
+
+    @Override
+    public String getFileExtension() {
+        return ".json";
+    }
+
+    @Override
+    public List<ObjectMarshalledProvenance> deserializeFromFile(Path path) throws IOException {
+        List<MarshalledProvenance> jsonProvenances = mapper.readValue(path.toFile(), typeRef);
+        List<ObjectMarshalledProvenance> jps = new ArrayList<>();
+        for (MarshalledProvenance mp : jsonProvenances) {
+            if (mp instanceof ObjectMarshalledProvenance) {
+                jps.add((ObjectMarshalledProvenance) mp);
+            } else {
+                throw new IllegalArgumentException("Invalid provenance found, expected ObjectMarshalledProvenance, found " + mp);
+            }
+        }
+        return jps;
+    }
+
+    @Override
+    public List<ObjectMarshalledProvenance> deserializeFromString(String input) {
+        try {
+            List<MarshalledProvenance> jsonProvenances = mapper.readValue(input, typeRef);
+            List<ObjectMarshalledProvenance> jps = new ArrayList<>();
+            for (MarshalledProvenance mp : jsonProvenances) {
+                if (mp instanceof ObjectMarshalledProvenance) {
+                    jps.add((ObjectMarshalledProvenance) mp);
+                } else {
+                    throw new IllegalArgumentException("Invalid provenance found, expected ObjectMarshalledProvenance, found " + mp);
+                }
+            }
+            return jps;
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to deserialize provenance", e);
+        }
+    }
+
+    @Override
+    public String serializeToString(List<ObjectMarshalledProvenance> marshalledProvenances) {
+        try {
+            return mapper.writeValueAsString(marshalledProvenances);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize provenance", e);
+        }
+    }
+
+    @Override
+    public void serializeToFile(List<ObjectMarshalledProvenance> marshalledProvenances, Path path) throws IOException {
+        try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(path.toFile())))) {
+            writer.println(serializeToString(marshalledProvenances));
+        }
+    }
+}

--- a/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceMarshaller.java
+++ b/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceMarshaller.java
@@ -68,7 +68,7 @@ public final class JsonProvenanceMarshaller implements ProvenanceMarshaller {
 
     @Override
     public String getFileExtension() {
-        return ".json";
+        return "json";
     }
 
     @Override

--- a/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceSerialization.java
+++ b/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceSerialization.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.oracle.labs.mlrg.olcut.provenance.io.MarshalledProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
-import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceMarshaller;
+import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceSerialization;
 import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceSerializationException;
 
 import java.io.BufferedWriter;
@@ -50,18 +50,18 @@ import java.util.List;
 /**
  * Class for serializing and deserializing provenances to/from json.
  */
-public final class JsonProvenanceMarshaller implements ProvenanceMarshaller {
+public final class JsonProvenanceSerialization implements ProvenanceSerialization {
 
     private static final TypeReference<List<MarshalledProvenance>> typeRef = new TypeReference<List<MarshalledProvenance>>() {};
 
     private final ObjectMapper mapper;
 
     /**
-     * Construct a JsonProvenanceMarshaller.
+     * Construct a JsonProvenanceSerialization.
      *
      * @param indentOutput Indent the output.
      */
-    public JsonProvenanceMarshaller(boolean indentOutput) {
+    public JsonProvenanceSerialization(boolean indentOutput) {
         mapper = new ObjectMapper();
         mapper.registerModule(new JsonProvenanceModule());
         if (indentOutput) {

--- a/olcut-config-json/src/test/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceConversionTest.java
+++ b/olcut-config-json/src/test/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceConversionTest.java
@@ -28,9 +28,6 @@
 
 package com.oracle.labs.mlrg.olcut.config.json;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
 import com.oracle.labs.mlrg.olcut.provenance.ExampleProvenancableConfigurable;
 import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
@@ -38,37 +35,28 @@ import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.Provenance;
 import com.oracle.labs.mlrg.olcut.provenance.ProvenanceConversionTest.SimpleObjectProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
-import com.oracle.labs.mlrg.olcut.provenance.io.MarshalledProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.SplittableRandom;
 
 import static com.oracle.labs.mlrg.olcut.provenance.ProvenanceConversionTest.constructProvenance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  *
  */
 public class JsonProvenanceConversionTest {
-    private File f;
-    private ObjectMapper mapper;
+    private JsonProvenanceMarshaller marshaller;
 
     @BeforeEach
     public void setUp() throws IOException {
         ConfigurationManager.addFileFormatFactory(new JsonConfigFactory());
-        mapper = new ObjectMapper();
-        mapper.registerModule(new JsonProvenanceModule());
-        mapper.enable(SerializationFeature.INDENT_OUTPUT);
-        f = File.createTempFile("provenance", ".json");
-        f.deleteOnExit();
+        marshaller = new JsonProvenanceMarshaller(true);
     }
 
     @Test
@@ -82,20 +70,11 @@ public class JsonProvenanceConversionTest {
         List<ObjectMarshalledProvenance> marshalledProvenances = ProvenanceUtil.marshalProvenance(provenance);
         assertEquals(8,marshalledProvenances.size());
 
-        String jsonResult = mapper.writeValueAsString(marshalledProvenances);
+        String jsonResult = marshaller.serializeToString(marshalledProvenances);
 
-        List<MarshalledProvenance> jsonProvenances = mapper.readValue(jsonResult, new TypeReference<List<MarshalledProvenance>>(){});
+        List<ObjectMarshalledProvenance> jsonProvenances = marshaller.deserializeFromString(jsonResult);
 
-        List<ObjectMarshalledProvenance> jps = new ArrayList<>();
-        for (MarshalledProvenance mp : jsonProvenances) {
-            if (mp instanceof ObjectMarshalledProvenance) {
-                jps.add((ObjectMarshalledProvenance) mp);
-            } else {
-                fail("Unexpected provenance deserialized.");
-            }
-        }
-
-        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jps);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jsonProvenances);
 
         assertEquals(provenance,unmarshalledProvenance);
     }
@@ -112,20 +91,11 @@ public class JsonProvenanceConversionTest {
 
         assertEquals(1,marshalledProvenance.size());
 
-        String jsonResult = mapper.writeValueAsString(marshalledProvenance);
+        String jsonResult = marshaller.serializeToString(marshalledProvenance);
 
-        List<MarshalledProvenance> jsonProvenances = mapper.readValue(jsonResult, new TypeReference<List<MarshalledProvenance>>(){});
+        List<ObjectMarshalledProvenance> jsonProvenances = marshaller.deserializeFromString(jsonResult);
 
-        List<ObjectMarshalledProvenance> jps = new ArrayList<>();
-        for (MarshalledProvenance mp : jsonProvenances) {
-            if (mp instanceof ObjectMarshalledProvenance) {
-                jps.add((ObjectMarshalledProvenance) mp);
-            } else {
-                fail("Unexpected provenance deserialized.");
-            }
-        }
-
-        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jps);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jsonProvenances);
 
         assertEquals(objProv,unmarshalledProvenance);
     }

--- a/olcut-config-json/src/test/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceSerializationTest.java
+++ b/olcut-config-json/src/test/java/com/oracle/labs/mlrg/olcut/config/json/JsonProvenanceSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *
@@ -26,13 +26,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.oracle.labs.mlrg.olcut.provenance;
+package com.oracle.labs.mlrg.olcut.config.json;
 
 import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
+import com.oracle.labs.mlrg.olcut.provenance.ExampleProvenancableConfigurable;
+import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.Provenance;
 import com.oracle.labs.mlrg.olcut.provenance.ProvenanceConversionTest.SimpleObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
 import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceSerializationException;
-import com.oracle.labs.mlrg.olcut.provenance.io.XMLProvenanceMarshaller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,12 +51,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  *
  */
-public class XmlProvenanceConversionTest {
-    private XMLProvenanceMarshaller marshaller;
+public class JsonProvenanceSerializationTest {
+    private final JsonProvenanceSerialization marshaller = new JsonProvenanceSerialization(true);
 
     @BeforeEach
     public void setUp() throws IOException {
-        marshaller = new XMLProvenanceMarshaller(true);
+        ConfigurationManager.addFileFormatFactory(new JsonConfigFactory());
     }
 
     @Test
@@ -66,11 +70,11 @@ public class XmlProvenanceConversionTest {
         List<ObjectMarshalledProvenance> marshalledProvenances = ProvenanceUtil.marshalProvenance(provenance);
         assertEquals(8,marshalledProvenances.size());
 
-        String xmlResult = marshaller.serializeToString(marshalledProvenances);
+        String jsonResult = marshaller.serializeToString(marshalledProvenances);
 
-        List<ObjectMarshalledProvenance> xmlProvenances = marshaller.deserializeFromString(xmlResult);
+        List<ObjectMarshalledProvenance> jsonProvenances = marshaller.deserializeFromString(jsonResult);
 
-        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(xmlProvenances);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jsonProvenances);
 
         assertEquals(provenance,unmarshalledProvenance);
     }
@@ -87,11 +91,11 @@ public class XmlProvenanceConversionTest {
 
         assertEquals(1,marshalledProvenance.size());
 
-        String xmlResult = marshaller.serializeToString(marshalledProvenance);
+        String jsonResult = marshaller.serializeToString(marshalledProvenance);
 
-        List<ObjectMarshalledProvenance> xmlProvenances = marshaller.deserializeFromString(xmlResult);
+        List<ObjectMarshalledProvenance> jsonProvenances = marshaller.deserializeFromString(jsonResult);
 
-        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(xmlProvenances);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jsonProvenances);
 
         assertEquals(objProv,unmarshalledProvenance);
     }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/FlatMarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/FlatMarshalledProvenance.java
@@ -31,7 +31,7 @@ package com.oracle.labs.mlrg.olcut.provenance.io;
 /**
  * A marshalled provenance that is either a {@link ListMarshalledProvenance},
  * a {@link MapMarshalledProvenance} or a {@link SimpleMarshalledProvenance}.
- *
+ * <p>
  * Will be sealed to those types one day.
  */
 public interface FlatMarshalledProvenance extends MarshalledProvenance { }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ListMarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ListMarshalledProvenance.java
@@ -43,6 +43,10 @@ public final class ListMarshalledProvenance implements FlatMarshalledProvenance,
 
     private final List<FlatMarshalledProvenance> list;
 
+    /**
+     * Constructs a ListMarshalledProvenance wrapped around the supplied list.
+     * @param list The list.
+     */
     public ListMarshalledProvenance(List<FlatMarshalledProvenance> list) {
         this.list = Collections.unmodifiableList(list);
     }
@@ -70,7 +74,7 @@ public final class ListMarshalledProvenance implements FlatMarshalledProvenance,
 
     @Override
     public String toString() {
-        return list.toString();
+        return "ListMarshalledProvenance" + list.toString();
     }
 
     @Override

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/MapMarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/MapMarshalledProvenance.java
@@ -60,6 +60,14 @@ public final class MapMarshalledProvenance implements FlatMarshalledProvenance, 
         this.map = Collections.emptyMap();
     }
 
+    /**
+     * Is this MapMarshalledProvenance empty?
+     * @return True if the provenance contains no other provenances.
+     */
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
     @Override
     public Iterator<Pair<String, FlatMarshalledProvenance>> iterator() {
         return new MapMarshalledProvenanceIterator(map.entrySet().iterator());

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/MapMarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/MapMarshalledProvenance.java
@@ -45,10 +45,17 @@ public final class MapMarshalledProvenance implements FlatMarshalledProvenance, 
 
     private final Map<String, FlatMarshalledProvenance> map;
 
+    /**
+     * Constructs a MapMarshalledProvenance wrapped around the supplied map.
+     * @param map The map.
+     */
     public MapMarshalledProvenance(Map<String, FlatMarshalledProvenance> map) {
         this.map = Collections.unmodifiableMap(new HashMap<>(map));
     }
 
+    /**
+     * Constructs an empty MapMarshalledProvenance.
+     */
     public MapMarshalledProvenance() {
         this.map = Collections.emptyMap();
     }
@@ -60,7 +67,7 @@ public final class MapMarshalledProvenance implements FlatMarshalledProvenance, 
 
     @Override
     public String toString() {
-        return map.toString();
+        return "MapMarshalledProvenance" + map.toString();
     }
 
     @Override
@@ -95,6 +102,5 @@ public final class MapMarshalledProvenance implements FlatMarshalledProvenance, 
             return new Pair<>(item.getKey(),item.getValue());
         }
     }
-
 
 }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/MarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/MarshalledProvenance.java
@@ -30,7 +30,7 @@ package com.oracle.labs.mlrg.olcut.provenance.io;
 
 /**
  * An interface for marshalled provenance types.
- *
+ * <p>
  * Will be sealed to {@link FlatMarshalledProvenance} and {@link ObjectMarshalledProvenance}
  * one day.
  */

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ObjectMarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ObjectMarshalledProvenance.java
@@ -35,7 +35,7 @@ import java.util.Objects;
 /**
  * A marshalled provenance representing an
  * {@link com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance} subclass.
- *
+ * <p>
  * Contains the name of the object, the class name of the provenance's host object,
  * and the class name of the provenance object.
  */
@@ -49,6 +49,13 @@ public final class ObjectMarshalledProvenance implements MarshalledProvenance {
 
     private final String provenanceClassName;
 
+    /**
+     * Constructs an ObjectMarshalledProvenance.
+     * @param objectName The name of the object in the provenance stream.
+     * @param map The object's fields.
+     * @param objectClassName The class name of the {@link com.oracle.labs.mlrg.olcut.provenance.Provenancable} object.
+     * @param provenanceClassName The class name of the {@link com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance} subclass.
+     */
     public ObjectMarshalledProvenance(String objectName, Map<String, FlatMarshalledProvenance> map, String objectClassName, String provenanceClassName) {
         this.objectName = objectName;
         this.map = Collections.unmodifiableMap(map);
@@ -56,18 +63,34 @@ public final class ObjectMarshalledProvenance implements MarshalledProvenance {
         this.provenanceClassName = provenanceClassName;
     }
 
+    /**
+     * Gets the object name.
+     * @return The object name.
+     */
     public String getName() {
         return objectName;
     }
 
+    /**
+     * The fields of the provenance.
+     * @return The provenance fields.
+     */
     public Map<String, FlatMarshalledProvenance> getMap() {
         return map;
     }
 
+    /**
+     * The class name of the {@link com.oracle.labs.mlrg.olcut.provenance.Provenancable} object.
+     * @return The creator class of the provenance.
+     */
     public String getObjectClassName() {
         return objectClassName;
     }
 
+    /**
+     * The class name of the {@link com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance} subclass.
+     * @return The provenance class name.
+     */
     public String getProvenanceClassName() {
         return provenanceClassName;
     }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ProvenanceMarshaller.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ProvenanceMarshaller.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the 2-clause BSD license.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.labs.mlrg.olcut.provenance.io;
+
+import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Interface for serializing and deserializing marshalled provenances to
+ * and from strings or files.
+ */
+public interface ProvenanceMarshaller {
+
+    /**
+     * The file extension this ProvenanceMarshaller supports.
+     * @return The file extension.
+     */
+    public String getFileExtension();
+
+    /**
+     * Loads in a list of marshalled provenances from the specified file.
+     * @param path The file to load.
+     * @return The marshalled provenances in the file.
+     * @throws IOException If the file failed to read.
+     */
+    public List<ObjectMarshalledProvenance> deserializeFromFile(Path path) throws IOException;
+
+    /**
+     * Loads in a list of marshalled provenances from the supplied string.
+     * @param input The string to deserialize.
+     * @return The marshalled provenances in the string.
+     */
+    public List<ObjectMarshalledProvenance> deserializeFromString(String input);
+
+    /**
+     * Deserializes and unmarshalls the provenances in the specified file.
+     * @param path The file to load.
+     * @return The object provenance specified by the marshalled provenances in the file.
+     * @throws IOException If the file failed to read.
+     */
+    default public ObjectProvenance deserializeAndUnmarshal(Path path) throws IOException {
+        return ProvenanceUtil.unmarshalProvenance(deserializeFromFile(path));
+    }
+
+    /**
+     * Deserializes and unmarshalls the provenances from the supplied string..
+     * @param input The string to deserialize.
+     * @return The object provenance specified by the marshalled provenances in the string.
+     */
+    default public ObjectProvenance deserializeAndUnmarshal(String input) {
+        return ProvenanceUtil.unmarshalProvenance(deserializeFromString(input));
+    }
+
+    /**
+     * Serializes the list of marshalled provenance to a string.
+     * @param marshalledProvenances The provenances to serialize.
+     * @return A string serialized form of the marshalled provenances.
+     */
+    public String serializeToString(List<ObjectMarshalledProvenance> marshalledProvenances);
+
+    /**
+     * Serializes the list of marshalled provenances to the specified file.
+     * @param marshalledProvenances The provenances to serialize.
+     * @param path The path to serialize to.
+     * @throws IOException If the file could not be written.
+     */
+    public void serializeToFile(List<ObjectMarshalledProvenance> marshalledProvenances, Path path) throws IOException;
+
+    /**
+     * Marshalls and serializes the supplied provenance to a string.
+     * @param provenance The provenance to serialize.
+     * @return A string serialized form of the marshalled provenances.
+     */
+    default public String marshalAndSerialize(ObjectProvenance provenance) {
+        return serializeToString(ProvenanceUtil.marshalProvenance(provenance));
+    }
+
+    /**
+     * Marhsalls and serializes the supplied provenance to the specified file.
+     * @param provenance The provenance to serialize.
+     * @param path The path to serialize to.
+     * @throws IOException If the file could not be written.
+     */
+    default public void marshalAndSerialize(ObjectProvenance provenance, Path path) throws IOException {
+        serializeToFile(ProvenanceUtil.marshalProvenance(provenance),path);
+    }
+}

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ProvenanceSerialization.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/ProvenanceSerialization.java
@@ -39,10 +39,10 @@ import java.util.List;
  * Interface for serializing and deserializing marshalled provenances to
  * and from strings or files.
  */
-public interface ProvenanceMarshaller {
+public interface ProvenanceSerialization {
 
     /**
-     * The file extension this ProvenanceMarshaller supports.
+     * The file extension this ProvenanceSerialization supports.
      * @return The file extension.
      */
     public String getFileExtension();

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/SimpleMarshalledProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/SimpleMarshalledProvenance.java
@@ -61,7 +61,7 @@ import java.util.Objects;
 /**
  * A marshalled provenance representing a primitive type, or a reference to
  * another {@link ObjectMarshalledProvenance} in the marshalled object stream.
- *
+ * <p>
  * If the {@link PrimitiveProvenance} requires extra information beyond it's
  * key and value, this class must be updated to have a specific constructor
  * for that type.
@@ -243,7 +243,7 @@ public final class SimpleMarshalledProvenance implements FlatMarshalledProvenanc
 
     /**
      * Any additional information necessary beyond the key and value,
-     * e.g. the hash type.
+     * e.g., the hash type.
      * @return Any additional information necessary to encode the provenance.
      */
     public String getAdditional() {

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/XMLProvenanceMarshaller.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/XMLProvenanceMarshaller.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the 2-clause BSD license.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.labs.mlrg.olcut.provenance.io;
+
+import com.oracle.labs.mlrg.olcut.util.Pair;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class for serializing and deserializing provenances to/from xml.
+ */
+public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
+
+    /**
+     * Container for all provenances.
+     */
+    public static final String PROVENANCES = "provenances";
+    /**
+     * {@link ObjectMarshalledProvenance} element.
+     */
+    public static final String OBJECT_MARSHALLED_PROVENANCE = "object-provenance";
+    /**
+     * {@link ListMarshalledProvenance} element.
+     */
+    public static final String LIST_MARSHALLED_PROVENANCE = "list-provenance";
+    /**
+     * {@link MapMarshalledProvenance} element.
+     */
+    public static final String MAP_MARSHALLED_PROVENANCE = "map-provenance";
+    /**
+     * {@link SimpleMarshalledProvenance} element.
+     */
+    public static final String SIMPLE_MARSHALLED_PROVENANCE = "simple-provenance";
+    /**
+     * Object name attribute.
+     */
+    public static final String OBJECT_NAME = "obj-name";
+    /**
+     * Object class name attribute.
+     */
+    public static final String OBJECT_CLASS_NAME = "class-name";
+    /**
+     * Provenance class name attribute.
+     */
+    public static final String PROVENANCE_CLASS_NAME = "prov-class-name";
+    /**
+     * Provenance key attribute.
+     */
+    public static final String PROV_KEY = "key";
+    /**
+     * {@link SimpleMarshalledProvenance} value attribute.
+     */
+    public static final String PROV_VALUE = "value";
+    /**
+     * {@link SimpleMarshalledProvenance} additional value attribute.
+     */
+    public static final String PROV_ADDITIONAL = "additional";
+    /**
+     * {@link SimpleMarshalledProvenance} is reference atttribute.
+     */
+    public static final String IS_REFERENCE = "is-reference";
+
+    private final XMLOutputFactory factory = XMLOutputFactory.newFactory();
+
+    private final boolean prettyPrint;
+
+    /**
+     * Constructs an XMLProvenanceMarshaller.
+     *
+     * @param prettyPrint Print tabs and newlines to appropriately format the XML output for readability.
+     */
+    public XMLProvenanceMarshaller(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
+    }
+
+    @Override
+    public String getFileExtension() {
+        return "xml";
+    }
+
+    @Override
+    public List<ObjectMarshalledProvenance> deserializeFromFile(Path path) throws IOException {
+        return null;
+    }
+
+    @Override
+    public List<ObjectMarshalledProvenance> deserializeFromString(String input) {
+        return null;
+    }
+
+    @Override
+    public String serializeToString(List<ObjectMarshalledProvenance> marshalledProvenances) {
+        try {
+            StringWriter strWriter = new StringWriter();
+            XMLStreamWriter writer = factory.createXMLStreamWriter(strWriter);
+            writeProvenance(writer, marshalledProvenances);
+            return strWriter.toString();
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException("Failed to serialize to XML", e);
+        }
+    }
+
+    @Override
+    public void serializeToFile(List<ObjectMarshalledProvenance> marshalledProvenances, Path path) throws IOException {
+        try (BufferedOutputStream bos = new BufferedOutputStream(Files.newOutputStream(path))) {
+            XMLStreamWriter writer = factory.createXMLStreamWriter(bos, "utf-8");
+            writeProvenance(writer, marshalledProvenances);
+        } catch (XMLStreamException e) {
+            throw new IllegalArgumentException("Failed to serialize to XML", e);
+        }
+    }
+
+    /**
+     * Writes the provenance to the XML stream.
+     *
+     * @param writer                The XML writer.
+     * @param marshalledProvenances The provenances.
+     */
+    private void writeProvenance(XMLStreamWriter writer, List<ObjectMarshalledProvenance> marshalledProvenances) throws XMLStreamException {
+        // write preamble
+        writer.writeStartDocument("utf-8", "1.0");
+        if (prettyPrint) {
+            writer.writeCharacters(System.lineSeparator());
+        }
+        writer.writeStartElement(PROVENANCES);
+        if (prettyPrint) {
+            writer.writeCharacters(System.lineSeparator());
+        }
+
+        // write the provenances
+        for (ObjectMarshalledProvenance omp : marshalledProvenances) {
+            writeOMP(writer, omp);
+        }
+
+        // write end document, closing all tags
+        writer.writeEndDocument();
+    }
+
+    /**
+     * Writes the supplied ObjectMarshalledProvenance to the XML stream.
+     *
+     * @param writer The XML writer.
+     * @param omp    The provenance.
+     * @throws XMLStreamException If the XML is invalid.
+     */
+    private void writeOMP(XMLStreamWriter writer, ObjectMarshalledProvenance omp) throws XMLStreamException {
+        Map<String, FlatMarshalledProvenance> provMap = omp.getMap();
+        if (prettyPrint) {
+            writer.writeCharacters("\t");
+        }
+        if (!provMap.isEmpty()) {
+            writer.writeStartElement(OBJECT_MARSHALLED_PROVENANCE);
+        } else {
+            writer.writeEmptyElement(OBJECT_MARSHALLED_PROVENANCE);
+        }
+        writer.writeAttribute(OBJECT_NAME, omp.getName());
+        writer.writeAttribute(OBJECT_CLASS_NAME, omp.getObjectClassName());
+        writer.writeAttribute(PROVENANCE_CLASS_NAME, omp.getProvenanceClassName());
+        if (!provMap.isEmpty()) {
+            if (prettyPrint) {
+                writer.writeCharacters(System.lineSeparator());
+            }
+            for (Map.Entry<String,FlatMarshalledProvenance> e : provMap.entrySet()) {
+                dispatchFMP(writer,e.getKey(),e.getValue(),2);
+            }
+            if (prettyPrint) {
+                writer.writeCharacters("\t");
+            }
+            writer.writeEndElement();
+        }
+        if (prettyPrint) {
+            writer.writeCharacters(System.lineSeparator());
+        }
+    }
+
+    /**
+     * Writes the supplied SimpleMarshalledProvenance to the XML stream.
+     * @param writer The XML writer.
+     * @param smp The provenance to write.
+     * @param depth The depth for tabbing in the pretty print.
+     * @throws XMLStreamException If the XML is invalid.
+     */
+    private void writeSMP(XMLStreamWriter writer, SimpleMarshalledProvenance smp, int depth) throws XMLStreamException {
+        if (prettyPrint) {
+            for (int i = 0; i < depth; i++) {
+                writer.writeCharacters("\t");
+            }
+        }
+        writer.writeEmptyElement(SIMPLE_MARSHALLED_PROVENANCE);
+        writer.writeAttribute(PROV_KEY, smp.getKey());
+        writer.writeAttribute(PROV_VALUE, smp.getValue());
+        writer.writeAttribute(PROV_ADDITIONAL, smp.getAdditional());
+        writer.writeAttribute(PROVENANCE_CLASS_NAME, smp.getProvenanceClassName());
+        writer.writeAttribute(IS_REFERENCE, ""+smp.isReference());
+        if (prettyPrint) {
+            writer.writeCharacters(System.lineSeparator());
+        }
+    }
+
+    /**
+     * Writes the supplied ListMarshalledProvenance to the XML stream.
+     * @param writer The XML writer.
+     * @param lmp The provenance to write.
+     * @param depth The depth for tabbing in the pretty print.
+     * @throws XMLStreamException If the XML is invalid.
+     */
+    private void writeLMP(XMLStreamWriter writer, String key, ListMarshalledProvenance lmp, int depth) throws XMLStreamException {
+        if (prettyPrint) {
+            for (int i = 0; i < depth; i++) {
+                writer.writeCharacters("\t");
+            }
+        }
+        if (lmp.getList().isEmpty()) {
+            writer.writeEmptyElement(LIST_MARSHALLED_PROVENANCE);
+            writer.writeAttribute(PROV_KEY, key);
+        } else {
+            writer.writeStartElement(LIST_MARSHALLED_PROVENANCE);
+            writer.writeAttribute(PROV_KEY, key);
+            if (prettyPrint) {
+                writer.writeCharacters(System.lineSeparator());
+            }
+            for (FlatMarshalledProvenance fmp : lmp.getList()) {
+                dispatchFMP(writer,"",fmp,depth+1);
+            }
+            if (prettyPrint) {
+                for (int i = 0; i < depth; i++) {
+                    writer.writeCharacters("\t");
+                }
+            }
+            writer.writeEndElement();
+        }
+        if (prettyPrint) {
+            writer.writeCharacters(System.lineSeparator());
+        }
+    }
+
+    /**
+     * Writes the supplied MapMarshalledProvenance to the XML stream.
+     * @param writer The XML writer.
+     * @param mmp The provenance to write.
+     * @param depth The depth for tabbing in the pretty print.
+     * @throws XMLStreamException If the XML is invalid.
+     */
+    private void writeMMP(XMLStreamWriter writer, String key, MapMarshalledProvenance mmp, int depth) throws XMLStreamException {
+        if (prettyPrint) {
+            for (int i = 0; i < depth; i++) {
+                writer.writeCharacters("\t");
+            }
+        }
+        if (mmp.isEmpty()) {
+            writer.writeEmptyElement(MAP_MARSHALLED_PROVENANCE);
+            writer.writeAttribute(PROV_KEY, key);
+        } else {
+            writer.writeStartElement(MAP_MARSHALLED_PROVENANCE);
+            writer.writeAttribute(PROV_KEY, key);
+            if (prettyPrint) {
+                writer.writeCharacters(System.lineSeparator());
+            }
+            for (Pair<String,FlatMarshalledProvenance> p : mmp) {
+                dispatchFMP(writer,p.getA(),p.getB(),depth+1);
+            }
+            if (prettyPrint) {
+                for (int i = 0; i < depth; i++) {
+                    writer.writeCharacters("\t");
+                }
+            }
+            writer.writeEndElement();
+        }
+        if (prettyPrint) {
+            writer.writeCharacters(System.lineSeparator());
+        }
+    }
+
+    /**
+     * Dispatch on the type of FlatMarshalledProvenance.
+     * @param writer The XML writer.
+     * @param key The key of the containing provenance.
+     * @param fmp The FMP to dispatch on.
+     * @param depth The depth for tabbing in the pretty print.
+     * @throws XMLStreamException If the XML is invalid.
+     */
+    private void dispatchFMP(XMLStreamWriter writer, String key, FlatMarshalledProvenance fmp, int depth) throws XMLStreamException {
+        if (fmp instanceof SimpleMarshalledProvenance) {
+            SimpleMarshalledProvenance smp = (SimpleMarshalledProvenance) fmp;
+            writeSMP(writer,smp,depth);
+        } else if (fmp instanceof ListMarshalledProvenance) {
+            ListMarshalledProvenance lmp = (ListMarshalledProvenance) fmp;
+            writeLMP(writer,key,lmp,depth);
+        } else if (fmp instanceof MapMarshalledProvenance) {
+            MapMarshalledProvenance mmp = (MapMarshalledProvenance) fmp;
+            writeMMP(writer,key,mmp,depth);
+        } else {
+            throw new RuntimeException("Should not reach here, unexpected FlatMarshalledProvenance subclass " + fmp.getClass());
+        }
+    }
+}
+

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/XMLProvenanceMarshaller.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/XMLProvenanceMarshaller.java
@@ -195,8 +195,8 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
             if (prettyPrint) {
                 writer.writeCharacters(System.lineSeparator());
             }
-            for (Map.Entry<String,FlatMarshalledProvenance> e : provMap.entrySet()) {
-                dispatchFMP(writer,e.getKey(),e.getValue(),2);
+            for (Map.Entry<String, FlatMarshalledProvenance> e : provMap.entrySet()) {
+                dispatchFMP(writer, e.getKey(), e.getValue(), 2);
             }
             if (prettyPrint) {
                 writer.writeCharacters("\t");
@@ -210,9 +210,10 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
 
     /**
      * Writes the supplied SimpleMarshalledProvenance to the XML stream.
+     *
      * @param writer The XML writer.
-     * @param smp The provenance to write.
-     * @param depth The depth for tabbing in the pretty print.
+     * @param smp    The provenance to write.
+     * @param depth  The depth for tabbing in the pretty print.
      * @throws XMLStreamException If the XML is invalid.
      */
     private void writeSMP(XMLStreamWriter writer, SimpleMarshalledProvenance smp, int depth) throws XMLStreamException {
@@ -226,7 +227,7 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
         writer.writeAttribute(PROV_VALUE, smp.getValue());
         writer.writeAttribute(PROV_ADDITIONAL, smp.getAdditional());
         writer.writeAttribute(PROVENANCE_CLASS_NAME, smp.getProvenanceClassName());
-        writer.writeAttribute(IS_REFERENCE, ""+smp.isReference());
+        writer.writeAttribute(IS_REFERENCE, "" + smp.isReference());
         if (prettyPrint) {
             writer.writeCharacters(System.lineSeparator());
         }
@@ -234,9 +235,10 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
 
     /**
      * Writes the supplied ListMarshalledProvenance to the XML stream.
+     *
      * @param writer The XML writer.
-     * @param lmp The provenance to write.
-     * @param depth The depth for tabbing in the pretty print.
+     * @param lmp    The provenance to write.
+     * @param depth  The depth for tabbing in the pretty print.
      * @throws XMLStreamException If the XML is invalid.
      */
     private void writeLMP(XMLStreamWriter writer, String key, ListMarshalledProvenance lmp, int depth) throws XMLStreamException {
@@ -255,7 +257,7 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
                 writer.writeCharacters(System.lineSeparator());
             }
             for (FlatMarshalledProvenance fmp : lmp.getList()) {
-                dispatchFMP(writer,"",fmp,depth+1);
+                dispatchFMP(writer, "", fmp, depth + 1);
             }
             if (prettyPrint) {
                 for (int i = 0; i < depth; i++) {
@@ -271,9 +273,10 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
 
     /**
      * Writes the supplied MapMarshalledProvenance to the XML stream.
+     *
      * @param writer The XML writer.
-     * @param mmp The provenance to write.
-     * @param depth The depth for tabbing in the pretty print.
+     * @param mmp    The provenance to write.
+     * @param depth  The depth for tabbing in the pretty print.
      * @throws XMLStreamException If the XML is invalid.
      */
     private void writeMMP(XMLStreamWriter writer, String key, MapMarshalledProvenance mmp, int depth) throws XMLStreamException {
@@ -291,8 +294,8 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
             if (prettyPrint) {
                 writer.writeCharacters(System.lineSeparator());
             }
-            for (Pair<String,FlatMarshalledProvenance> p : mmp) {
-                dispatchFMP(writer,p.getA(),p.getB(),depth+1);
+            for (Pair<String, FlatMarshalledProvenance> p : mmp) {
+                dispatchFMP(writer, p.getA(), p.getB(), depth + 1);
             }
             if (prettyPrint) {
                 for (int i = 0; i < depth; i++) {
@@ -308,22 +311,23 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
 
     /**
      * Dispatch on the type of FlatMarshalledProvenance.
+     *
      * @param writer The XML writer.
-     * @param key The key of the containing provenance.
-     * @param fmp The FMP to dispatch on.
-     * @param depth The depth for tabbing in the pretty print.
+     * @param key    The key of the containing provenance.
+     * @param fmp    The FMP to dispatch on.
+     * @param depth  The depth for tabbing in the pretty print.
      * @throws XMLStreamException If the XML is invalid.
      */
     private void dispatchFMP(XMLStreamWriter writer, String key, FlatMarshalledProvenance fmp, int depth) throws XMLStreamException {
         if (fmp instanceof SimpleMarshalledProvenance) {
             SimpleMarshalledProvenance smp = (SimpleMarshalledProvenance) fmp;
-            writeSMP(writer,smp,depth);
+            writeSMP(writer, smp, depth);
         } else if (fmp instanceof ListMarshalledProvenance) {
             ListMarshalledProvenance lmp = (ListMarshalledProvenance) fmp;
-            writeLMP(writer,key,lmp,depth);
+            writeLMP(writer, key, lmp, depth);
         } else if (fmp instanceof MapMarshalledProvenance) {
             MapMarshalledProvenance mmp = (MapMarshalledProvenance) fmp;
-            writeMMP(writer,key,mmp,depth);
+            writeMMP(writer, key, mmp, depth);
         } else {
             throw new RuntimeException("Should not reach here, unexpected FlatMarshalledProvenance subclass " + fmp.getClass());
         }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/XMLProvenanceSerialization.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/io/XMLProvenanceSerialization.java
@@ -59,7 +59,7 @@ import java.util.Map;
 /**
  * Class for serializing and deserializing provenances to/from xml.
  */
-public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
+public final class XMLProvenanceSerialization implements ProvenanceSerialization {
 
     /**
      * Container for all provenances.
@@ -116,11 +116,11 @@ public final class XMLProvenanceMarshaller implements ProvenanceMarshaller {
     private final boolean prettyPrint;
 
     /**
-     * Constructs an XMLProvenanceMarshaller.
+     * Constructs an XMLProvenanceSerialization.
      *
      * @param prettyPrint Print tabs and newlines to appropriately format the XML output for readability.
      */
-    public XMLProvenanceMarshaller(boolean prettyPrint) {
+    public XMLProvenanceSerialization(boolean prettyPrint) {
         this.prettyPrint = prettyPrint;
     }
 

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/XmlProvenanceConversionTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/XmlProvenanceConversionTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the 2-clause BSD license.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.oracle.labs.mlrg.olcut.provenance;
+
+import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
+import com.oracle.labs.mlrg.olcut.provenance.ProvenanceConversionTest.SimpleObjectProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
+import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceMarshaller;
+import com.oracle.labs.mlrg.olcut.provenance.io.XMLProvenanceMarshaller;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.SplittableRandom;
+
+import static com.oracle.labs.mlrg.olcut.provenance.ProvenanceConversionTest.constructProvenance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ *
+ */
+public class XmlProvenanceConversionTest {
+    private XMLProvenanceMarshaller marshaller;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        marshaller = new XMLProvenanceMarshaller(true);
+    }
+
+    @Test
+    public void marshallingTest() throws IOException {
+        ConfigurationManager cm1 = new ConfigurationManager("/com/oracle/labs/mlrg/olcut/provenance/example-provenance-config.xml");
+        ExampleProvenancableConfigurable e = (ExampleProvenancableConfigurable) cm1.lookup("example-config");
+        assertNotNull(e, "Failed to load example config");
+
+        ObjectProvenance provenance = e.getProvenance();
+
+        List<ObjectMarshalledProvenance> marshalledProvenances = ProvenanceUtil.marshalProvenance(provenance);
+        assertEquals(8,marshalledProvenances.size());
+
+        String xmlResult = marshaller.serializeToString(marshalledProvenances);
+        //marshaller.serializeToFile(marshalledProvenances, Paths.get("/","tmp","marshalling-test.xml"));
+
+        List<ObjectMarshalledProvenance> xmlProvenances = marshaller.deserializeFromString(xmlResult);
+
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(xmlProvenances);
+
+        assertEquals(provenance,unmarshalledProvenance);
+    }
+
+    @Test
+    public void recursiveMarshallingTest() throws IOException {
+        Provenance prov = constructProvenance(new SplittableRandom(42),5,3,"prov");
+
+        assertNotNull(prov);
+
+        SimpleObjectProvenance objProv = new SimpleObjectProvenance((ListProvenance<?>)prov);
+
+        List<ObjectMarshalledProvenance> marshalledProvenance = ProvenanceUtil.marshalProvenance(objProv);
+
+        assertEquals(1,marshalledProvenance.size());
+
+        String xmlResult = marshaller.serializeToString(marshalledProvenance);
+        //marshaller.serializeToFile(marshalledProvenance, Paths.get("/","tmp","recursive-marshalling-test.xml"));
+
+        List<ObjectMarshalledProvenance> xmlProvenances = marshaller.deserializeFromString(xmlResult);
+
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(xmlProvenances);
+
+        assertEquals(objProv,unmarshalledProvenance);
+    }
+
+}

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/XmlProvenanceSerializationTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/provenance/XmlProvenanceSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *
@@ -26,17 +26,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.oracle.labs.mlrg.olcut.config.json;
+package com.oracle.labs.mlrg.olcut.provenance;
 
 import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
-import com.oracle.labs.mlrg.olcut.provenance.ExampleProvenancableConfigurable;
-import com.oracle.labs.mlrg.olcut.provenance.ListProvenance;
-import com.oracle.labs.mlrg.olcut.provenance.ObjectProvenance;
-import com.oracle.labs.mlrg.olcut.provenance.Provenance;
 import com.oracle.labs.mlrg.olcut.provenance.ProvenanceConversionTest.SimpleObjectProvenance;
-import com.oracle.labs.mlrg.olcut.provenance.ProvenanceUtil;
 import com.oracle.labs.mlrg.olcut.provenance.io.ObjectMarshalledProvenance;
 import com.oracle.labs.mlrg.olcut.provenance.io.ProvenanceSerializationException;
+import com.oracle.labs.mlrg.olcut.provenance.io.XMLProvenanceSerialization;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,14 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  *
  */
-public class JsonProvenanceConversionTest {
-    private JsonProvenanceMarshaller marshaller;
-
-    @BeforeEach
-    public void setUp() throws IOException {
-        ConfigurationManager.addFileFormatFactory(new JsonConfigFactory());
-        marshaller = new JsonProvenanceMarshaller(true);
-    }
+public class XmlProvenanceSerializationTest {
+    private final XMLProvenanceSerialization marshaller = new XMLProvenanceSerialization(true);
 
     @Test
     public void marshallingTest() throws ProvenanceSerializationException {
@@ -71,11 +61,11 @@ public class JsonProvenanceConversionTest {
         List<ObjectMarshalledProvenance> marshalledProvenances = ProvenanceUtil.marshalProvenance(provenance);
         assertEquals(8,marshalledProvenances.size());
 
-        String jsonResult = marshaller.serializeToString(marshalledProvenances);
+        String xmlResult = marshaller.serializeToString(marshalledProvenances);
 
-        List<ObjectMarshalledProvenance> jsonProvenances = marshaller.deserializeFromString(jsonResult);
+        List<ObjectMarshalledProvenance> xmlProvenances = marshaller.deserializeFromString(xmlResult);
 
-        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jsonProvenances);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(xmlProvenances);
 
         assertEquals(provenance,unmarshalledProvenance);
     }
@@ -92,11 +82,11 @@ public class JsonProvenanceConversionTest {
 
         assertEquals(1,marshalledProvenance.size());
 
-        String jsonResult = marshaller.serializeToString(marshalledProvenance);
+        String xmlResult = marshaller.serializeToString(marshalledProvenance);
 
-        List<ObjectMarshalledProvenance> jsonProvenances = marshaller.deserializeFromString(jsonResult);
+        List<ObjectMarshalledProvenance> xmlProvenances = marshaller.deserializeFromString(xmlResult);
 
-        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(jsonProvenances);
+        ObjectProvenance unmarshalledProvenance = ProvenanceUtil.unmarshalProvenance(xmlProvenances);
 
         assertEquals(objProv,unmarshalledProvenance);
     }


### PR DESCRIPTION
Tribuo needs a plain text minimal dependency string serialization format for provenance to allow storage in ONNX model protobufs which only expose String metadata fields. This PR adds an XML serialization format for provenance. It's not particularly pretty, but it does work and is relatively minimal as XML goes.

I also added an interface for Provenance marshalling which the XML serializer implements and I added a wrapper class for the Json provenance serializer to simplify the use of that class (which previously required registering things with the Jackson `ObjectMapper`).

Once this PR is merged I'll update the protobuf provenance serialization class so it implements `ProvenanceMarshaller` and put in a PR for that too.