### PR TITLE
Adds support for configurable and provenancable boolean arrays

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
@@ -2083,6 +2083,10 @@ public class ConfigurationManager implements Closeable {
                                     for (double d : (double[]) field.get(configurable)) {
                                         stringList.add("" + d);
                                     }
+                                } else if (boolean.class.isAssignableFrom(arrayComponentType)) {
+                                    for (boolean d : (boolean[]) field.get(configurable)) {
+                                        stringList.add("" + d);
+                                    }
                                 } else if (String.class.isAssignableFrom(arrayComponentType)) {
                                     stringList.addAll(Arrays.asList((String[]) field.get(configurable)));
                                 } else {

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/ConfigurationManager.java
@@ -2084,8 +2084,8 @@ public class ConfigurationManager implements Closeable {
                                         stringList.add("" + d);
                                     }
                                 } else if (boolean.class.isAssignableFrom(arrayComponentType)) {
-                                    for (boolean d : (boolean[]) field.get(configurable)) {
-                                        stringList.add("" + d);
+                                    for (boolean b : (boolean[]) field.get(configurable)) {
+                                        stringList.add("" + b);
                                     }
                                 } else if (String.class.isAssignableFrom(arrayComponentType)) {
                                     stringList.addAll(Arrays.asList((String[]) field.get(configurable)));

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/FieldType.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/FieldType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/FieldType.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/FieldType.java
@@ -69,6 +69,7 @@ public enum FieldType {
     LONG_ARRAY(long[].class),
     FLOAT_ARRAY(float[].class),
     DOUBLE_ARRAY(double[].class),
+    BOOLEAN_ARRAY(boolean[].class),
     //Configurable classes
     CONFIGURABLE(Configurable.class),
     //Object array types
@@ -100,10 +101,10 @@ public enum FieldType {
     
     private final static Map<Class<?>,FieldType> m = new HashMap<>();
     
-    public final static EnumSet<FieldType> arrayTypes = EnumSet.of(BYTE_ARRAY, CHAR_ARRAY, SHORT_ARRAY,
-                                                                  INTEGER_ARRAY, LONG_ARRAY,
-                                                                  FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY,
-                                                                  CONFIGURABLE_ARRAY);
+    public final static EnumSet<FieldType> arrayTypes = EnumSet.of(BYTE_ARRAY, CHAR_ARRAY, SHORT_ARRAY, INTEGER_ARRAY, LONG_ARRAY,
+                                                                   FLOAT_ARRAY, DOUBLE_ARRAY,
+                                                                   BOOLEAN_ARRAY,
+                                                                   STRING_ARRAY, CONFIGURABLE_ARRAY);
 
     public final static EnumSet<FieldType> listTypes = EnumSet.of(LIST,SET,ENUM_SET);
 

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/PropertySheet.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/PropertySheet.java
@@ -85,7 +85,27 @@ import javax.management.ObjectName;
 public class PropertySheet<T extends Configurable> {
     private static final Logger logger = Logger.getLogger(PropertySheet.class.getName());
 
-    public enum StoredFieldType { LIST, MAP, STRING, NONE }
+    /**
+     * The way a field is stored in the configuration.
+     */
+    public enum StoredFieldType {
+        /**
+         * LIST stores List, array and Set.
+         */
+        LIST,
+        /**
+         * MAP stores Map.
+         */
+        MAP,
+        /**
+         * All non-collection field types are stored as STRING.
+         */
+        STRING,
+        /**
+         * Sentinel used for types which are not configurable.
+         */
+        NONE
+    }
 
     private final Map<String, Config> registeredProperties = new HashMap<>();
 

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/PropertySheet.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/PropertySheet.java
@@ -600,6 +600,14 @@ public class PropertySheet<T extends Configurable> {
                     throw new PropertyException(ex, instanceName, fieldName, String.format("%s does not specify an array of double", replaced.toString()));
                 }
                 break;
+            case BOOLEAN_ARRAY:
+                boolean[] ba = new boolean[replaced.size()];
+                int i = 0;
+                for (String v : replaced) {
+                    ba[i++] = Boolean.parseBoolean(v);
+                }
+                output = ba;
+                break;
         }
         classVals.removeAll(removeList);
         if (classVals.size() > 0) {

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/PropertySheet.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/PropertySheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/SkeletalConfiguredObjectProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/SkeletalConfiguredObjectProvenance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/SkeletalConfiguredObjectProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/SkeletalConfiguredObjectProvenance.java
@@ -239,6 +239,7 @@ public abstract class SkeletalConfiguredObjectProvenance implements ConfiguredOb
                             case LONG_ARRAY:
                             case FLOAT_ARRAY:
                             case DOUBLE_ARRAY:
+                            case BOOLEAN_ARRAY:
                                 map.put(f.getName(), convertPrimitiveArray(ft, f, f.get(host)));
                                 break;
                             case STRING_ARRAY:
@@ -343,6 +344,13 @@ public abstract class SkeletalConfiguredObjectProvenance implements ConfiguredOb
                 double[] array = (double[]) object;
                 for (double e : array) {
                     list.add(new DoubleProvenance(fieldName,e));
+                }
+                break;
+            }
+            case BOOLEAN_ARRAY:{
+                boolean[] array = (boolean[]) object;
+                for (boolean e : array) {
+                    list.add(new BooleanProvenance(fieldName,e));
                 }
                 break;
             }

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/SkeletalConfiguredObjectProvenance.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/provenance/impl/SkeletalConfiguredObjectProvenance.java
@@ -204,68 +204,72 @@ public abstract class SkeletalConfiguredObjectProvenance implements ConfiguredOb
                 Config configAnnotation = f.getAnnotation(Config.class);
                 if ((configAnnotation != null) && !configAnnotation.redact()) {
                     FieldType ft = FieldType.getFieldType(f);
-                    switch (ft) {
-                        case BOOLEAN:
-                        case BYTE:
-                        case CHAR:
-                        case SHORT:
-                        case INTEGER:
-                        case LONG:
-                        case FLOAT:
-                        case DOUBLE:
-                        case STRING:
-                        case FILE:
-                        case PATH:
-                        case URL:
-                        case DATE_TIME:
-                        case DATE:
-                        case TIME:
-                        case ENUM:
-                        case CONFIGURABLE:
-                        case ATOMIC_INTEGER:
-                        case ATOMIC_LONG:
-                            Optional<Provenance> opt = convertPrimitive(ft,f.getType(),f.getName(),f.get(host));
-                            if (opt.isPresent()) {
-                                map.put(f.getName(), opt.get());
+                    if (ft == null) {
+                        logger.log(Level.SEVERE, "Provenance and configuration not supported for field '" + f.getName() + "' of type '" + f.getType() + ", value not recorded.");
+                    } else {
+                        switch (ft) {
+                            case BOOLEAN:
+                            case BYTE:
+                            case CHAR:
+                            case SHORT:
+                            case INTEGER:
+                            case LONG:
+                            case FLOAT:
+                            case DOUBLE:
+                            case STRING:
+                            case FILE:
+                            case PATH:
+                            case URL:
+                            case DATE_TIME:
+                            case DATE:
+                            case TIME:
+                            case ENUM:
+                            case CONFIGURABLE:
+                            case ATOMIC_INTEGER:
+                            case ATOMIC_LONG:
+                                Optional<Provenance> opt = convertPrimitive(ft, f.getType(), f.getName(), f.get(host));
+                                if (opt.isPresent()) {
+                                    map.put(f.getName(), opt.get());
+                                }
+                                break;
+                            case BYTE_ARRAY:
+                            case CHAR_ARRAY:
+                            case SHORT_ARRAY:
+                            case INTEGER_ARRAY:
+                            case LONG_ARRAY:
+                            case FLOAT_ARRAY:
+                            case DOUBLE_ARRAY:
+                                map.put(f.getName(), convertPrimitiveArray(ft, f, f.get(host)));
+                                break;
+                            case STRING_ARRAY:
+                            case CONFIGURABLE_ARRAY:
+                                map.put(f.getName(), convertObjectArray(ft, f, (Object[]) f.get(host)));
+                                break;
+                            case LIST:
+                            case ENUM_SET:
+                            case SET: {
+                                List<Class<?>> genericClasses = PropertySheet.getGenericClass(f);
+                                if (genericClasses.size() != 1) {
+                                    logger.log(Level.SEVERE, "Invalid configurable field definition, field not recorded - found too many or too few generic type parameters for field " + f.getName());
+                                } else {
+                                    map.put(f.getName(), convertCollection(f, (Collection) f.get(host), genericClasses.get(0)));
+                                }
+                                break;
                             }
-                            break;
-                        case BYTE_ARRAY:
-                        case CHAR_ARRAY:
-                        case SHORT_ARRAY:
-                        case INTEGER_ARRAY:
-                        case LONG_ARRAY:
-                        case FLOAT_ARRAY:
-                        case DOUBLE_ARRAY:
-                            map.put(f.getName(), convertPrimitiveArray(ft, f, f.get(host)));
-                            break;
-                        case STRING_ARRAY:
-                        case CONFIGURABLE_ARRAY:
-                            map.put(f.getName(), convertObjectArray(ft, f, (Object[]) f.get(host)));
-                            break;
-                        case LIST:
-                        case ENUM_SET:
-                        case SET: {
-                            List<Class<?>> genericClasses = PropertySheet.getGenericClass(f);
-                            if (genericClasses.size() != 1) {
-                                logger.log(Level.SEVERE, "Invalid configurable field definition, field not recorded - found too many or too few generic type parameters for field " + f.getName());
-                            } else {
-                                map.put(f.getName(), convertCollection(f, (Collection) f.get(host), genericClasses.get(0)));
+                            case MAP: {
+                                List<Class<?>> genericClasses = PropertySheet.getGenericClass(f);
+                                if (genericClasses.size() != 2) {
+                                    logger.log(Level.SEVERE, "Invalid configurable field definition, field not recorded - found too many or too few generic type parameters for field " + f.getName());
+                                } else {
+                                    map.put(f.getName(), convertMap(f, (Map) f.get(host), genericClasses.get(1)));
+                                }
+                                break;
                             }
-                            break;
+                            case RANDOM:
+                            default:
+                                logger.log(Level.SEVERE, "Automatic provenance not supported for field type " + ft + ", field '" + f.getName() + "' not recorded.");
+                                break;
                         }
-                        case MAP: {
-                            List<Class<?>> genericClasses = PropertySheet.getGenericClass(f);
-                            if (genericClasses.size() != 2) {
-                                logger.log(Level.SEVERE, "Invalid configurable field definition, field not recorded - found too many or too few generic type parameters for field " + f.getName());
-                            } else {
-                                map.put(f.getName(), convertMap(f, (Map) f.get(host), genericClasses.get(1)));
-                            }
-                            break;
-                        }
-                        case RANDOM:
-                        default:
-                            logger.log(Level.SEVERE, "Automatic provenance not supported for field type " + ft + ", field '" + f.getName() + "' not recorded.");
-                            break;
                     }
                 }
                 f.setAccessible(accessible);

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfigurable.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfigurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfigurable.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfigurable.java
@@ -129,6 +129,9 @@ public class AllFieldsConfigurable implements Configurable, Provenancable<Config
     @Config
     public double[] doubleArrayField;
 
+    @Config
+    public boolean[] booleanArrayField;
+
     //Configurable classes
     @Config
     public Configurable configurableField;

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfiguredTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfiguredTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020, Oracle and/or its affiliates.
+ * Copyright (c) 2004-2021, Oracle and/or its affiliates.
  *
  * Licensed under the 2-clause BSD license.
  *

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfiguredTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/AllFieldsConfiguredTest.java
@@ -173,6 +173,7 @@ public class AllFieldsConfiguredTest {
         ac.longArrayField = new long[]{9223372036854775807L,9223372036854775806L,5L};
         ac.floatArrayField = new float[]{1.1f,2.3f,3.5f};
         ac.doubleArrayField = new double[]{1e-16,2e-16,3.16};
+        ac.booleanArrayField = new boolean[]{true,false,true};
 
         //Configurable classes
         ac.configurableField = new StringConfigurable("A","B","C");

--- a/olcut-core/src/test/resources/com/oracle/labs/mlrg/olcut/config/allConfig.xml
+++ b/olcut-core/src/test/resources/com/oracle/labs/mlrg/olcut/config/allConfig.xml
@@ -89,6 +89,11 @@
             <item>2e-16</item>
             <item>3.16</item>
         </propertylist>
+        <propertylist name="booleanArrayField">
+            <item>true</item>
+            <item>false</item>
+            <item>True</item>
+        </propertylist>
 
         <propertylist name="stringArrayField">
             <item>gibbons</item>

--- a/olcut-core/src/test/resources/com/oracle/labs/mlrg/olcut/config/allConfig.xml
+++ b/olcut-core/src/test/resources/com/oracle/labs/mlrg/olcut/config/allConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="US-ASCII"?>
 
 <!--
-  ~ Copyright (c) 2004-2020, Oracle and/or its affiliates.
+  ~ Copyright (c) 2004-2021, Oracle and/or its affiliates.
   ~
   ~ Licensed under the 2-clause BSD license.
   ~


### PR DESCRIPTION
Not sure why it wasn't there already, but this rounds out OLCUT's coverage of Java primitives to include all single dimensional primitive arrays.

I added it to the `AllFieldsConfigurable` and extended the tests based on it rather than add a new test specifically for boolean arrays.