### PR TITLE
Adds command to modify the log level from the command shell

### DIFF
--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandInterpreter.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandInterpreter.java
@@ -60,6 +60,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -1507,6 +1508,74 @@ public class CommandInterpreter extends Thread {
             ci.out = System.out;
             return "";
         }
+
+        /**
+         * Adjusts the level of a logger and tunes the root log handlers to emit that level. If a logger name
+         * is given, this will only escalate the handler level to finer levels than it is currently set to and will
+         * not deescalate them. If no logger name is given, the root handlers only are adjusted and without
+         * constraint.
+         *
+         * @param ci the command interpreter
+         * @param level the new level to set the log to
+         * @param loggerName the name of a logger (expects package or canonical class name)
+         * @return a string of command output
+         */
+        @Command(usage="<LogLevel> [<LoggerName>] - sets the logging level for a logger, if specified, or sets the root handler level")
+        public String setLogLevel(CommandInterpreter ci, String level, @Optional(val="") String loggerName) {
+            Level logLevel = null;
+            try {
+                //
+                // Verify our args.
+                logLevel = Level.parse(level);
+
+                //
+                // Logger names by convention are class or package names. Warn in that isn't the case to help
+                // prevent typo frustration.
+                if (!loggerName.isEmpty()) {
+                    // Is this a class name?
+                    try {
+                        Class.forName(loggerName);
+                    } catch (ClassNotFoundException e) {
+                        // Not a class - how about package name?
+                        if (!Arrays.stream(Package.getPackages())
+                                .anyMatch(p -> p.getName().startsWith(loggerName) && (p.getName().equals(loggerName) || p.getName().charAt(loggerName.length()) == '.'))) {
+                            // Not a package either
+                            ci.out.println("Warning: \"" + loggerName + "\" doesn't appear to be a class or package name");
+                        }
+                    }
+                    Logger target = Logger.getLogger(loggerName);
+                    target.setLevel(logLevel);
+                }
+
+                //
+                // Get the current Handler level.
+                Handler[] handlers = Logger.getLogger("").getHandlers();
+                if (handlers == null || handlers.length <= 0) {
+                    return "No root log handlers defined.";
+                }
+                Level currLevel = handlers[0].getLevel();
+
+                //
+                // Should we adjust the handler level too?  We should if no logger was specified
+                // or if the requested level is finer than the current level.
+                if (loggerName.isEmpty() || (logLevel.intValue() < currLevel.intValue())) {
+                    for (Handler h : handlers) {
+                        h.setLevel(logLevel);
+                    }
+                } else if (!loggerName.isEmpty() && logLevel.intValue() > currLevel.intValue()) {
+                    ci.out.println(logLevel.toString() + " is less fine than current "
+                            + currLevel.toString() + ", won't automatically deescalate the Handler level");
+                }
+            } catch (IllegalArgumentException e) {
+                return "Unknown log level: " + level;
+            }
+            if (loggerName.isEmpty()) {
+                return "Set root log handlers to " + logLevel.toString();
+            } else {
+                return "Log level set to " + logLevel.toString() + " for " + loggerName;
+            }
+        }
+
 
         @Override
         public String getName() {

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandInterpreter.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/command/CommandInterpreter.java
@@ -1527,47 +1527,48 @@ public class CommandInterpreter extends Thread {
                 //
                 // Verify our args.
                 logLevel = Level.parse(level);
-
-                //
-                // Logger names by convention are class or package names. Warn in that isn't the case to help
-                // prevent typo frustration.
-                if (!loggerName.isEmpty()) {
-                    // Is this a class name?
-                    try {
-                        Class.forName(loggerName);
-                    } catch (ClassNotFoundException e) {
-                        // Not a class - how about package name?
-                        if (!Arrays.stream(Package.getPackages())
-                                .anyMatch(p -> p.getName().startsWith(loggerName) && (p.getName().equals(loggerName) || p.getName().charAt(loggerName.length()) == '.'))) {
-                            // Not a package either
-                            ci.out.println("Warning: \"" + loggerName + "\" doesn't appear to be a class or package name");
-                        }
-                    }
-                    Logger target = Logger.getLogger(loggerName);
-                    target.setLevel(logLevel);
-                }
-
-                //
-                // Get the current Handler level.
-                Handler[] handlers = Logger.getLogger("").getHandlers();
-                if (handlers == null || handlers.length <= 0) {
-                    return "No root log handlers defined.";
-                }
-                Level currLevel = handlers[0].getLevel();
-
-                //
-                // Should we adjust the handler level too?  We should if no logger was specified
-                // or if the requested level is finer than the current level.
-                if (loggerName.isEmpty() || (logLevel.intValue() < currLevel.intValue())) {
-                    for (Handler h : handlers) {
-                        h.setLevel(logLevel);
-                    }
-                } else if (!loggerName.isEmpty() && logLevel.intValue() > currLevel.intValue()) {
-                    ci.out.println(logLevel.toString() + " is less fine than current "
-                            + currLevel.toString() + ", won't automatically deescalate the Handler level");
-                }
             } catch (IllegalArgumentException e) {
                 return "Unknown log level: " + level;
+            }
+
+
+            //
+            // Logger names by convention are class or package names. Warn in that isn't the case to help
+            // prevent typo frustration.
+            if (!loggerName.isEmpty()) {
+                // Is this a class name?
+                try {
+                    Class.forName(loggerName);
+                } catch (ClassNotFoundException e) {
+                    // Not a class - how about package name?
+                    if (!Arrays.stream(Package.getPackages())
+                            .anyMatch(p -> p.getName().startsWith(loggerName) && (p.getName().equals(loggerName) || p.getName().charAt(loggerName.length()) == '.'))) {
+                        // Not a package either
+                        ci.out.println("Warning: \"" + loggerName + "\" doesn't appear to be a class or package name");
+                    }
+                }
+                Logger target = Logger.getLogger(loggerName);
+                target.setLevel(logLevel);
+            }
+
+            //
+            // Get the current Handler level.
+            Handler[] handlers = Logger.getLogger("").getHandlers();
+            if (handlers == null || handlers.length <= 0) {
+                return "No root log handlers defined.";
+            }
+            Level currLevel = handlers[0].getLevel();
+
+            //
+            // Should we adjust the handler level too?  We should if no logger was specified
+            // or if the requested level is finer than the current level.
+            if (loggerName.isEmpty() || (logLevel.intValue() < currLevel.intValue())) {
+                for (Handler h : handlers) {
+                    h.setLevel(logLevel);
+                }
+            } else if (!loggerName.isEmpty() && logLevel.intValue() > currLevel.intValue()) {
+                ci.out.println(logLevel.toString() + " is less fine than current "
+                        + currLevel.toString() + ", won't automatically deescalate the Handler level");
             }
             if (loggerName.isEmpty()) {
                 return "Set root log handlers to " + logLevel.toString();

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/command/StandardCommandTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/command/StandardCommandTest.java
@@ -1,0 +1,108 @@
+package com.oracle.labs.mlrg.olcut.command;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jdk.jfr.internal.LogLevel;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * Tests for the standard commands in the CommandInterpreter.
+ * As unit tests have not existed for the shell, tests should be added
+ * here as any part of the shell is touched. Just add a new nested class
+ * for each command.
+ */
+public class StandardCommandTest {
+    public static final Logger logger = Logger.getLogger(StandardCommandTest.class.getName());
+
+    private CommandInterpreter ci;
+    private CommandInterpreter.StandardCommands cmds;
+    private Handler rootHandler;
+
+    @BeforeAll
+    public static void setup() {
+
+    }
+
+    @BeforeEach
+    public  void setupEach() {
+        //
+        // Start with a fresh command interpreter and bury and output
+        ci = new CommandInterpreter(false);
+        ci.setOutput(new PrintStream(new OutputStream() {
+            @Override
+            public void write(int b) {}
+        }));
+        cmds = ci.new StandardCommands();
+    }
+
+    @Nested
+    @DisplayName("Shell LogLevel Tests")
+    class LogLevelTests {
+        @BeforeEach
+        public void cleanLoggers() throws IOException {
+            // Outer class's BeforeEach runs before this one
+            LogManager logManager = LogManager.getLogManager();
+            logManager.readConfiguration();
+            rootHandler = Logger.getLogger("").getHandlers()[0];
+
+            LogRecord rec = new LogRecord(Level.INFO, "Test");
+            assertTrue(logger.isLoggable(rec.getLevel()) && rootHandler.isLoggable(rec), "Initial test state incorrect");
+            rec.setLevel(Level.FINE);
+            assertTrue(!logger.isLoggable(rec.getLevel()) && !rootHandler.isLoggable(rec), "Initial test state incorrect");
+        }
+
+        @Test
+        public void testLogLevelSpecificClass() {
+            LogRecord rec = new LogRecord(Level.FINE, "Test");
+            //
+            // Move the log level for this class
+            cmds.setLogLevel(ci, Level.FINE.getName(), StandardCommandTest.class.getName());
+            assertTrue(logger.isLoggable(rec.getLevel()), "FINE should be loggable in logger");
+            assertTrue(rootHandler.isLoggable(rec), "Failed to adjust level to FINE in handler");
+
+            //
+            // Move the log level back up. This should only move the logger and not the handler
+            cmds.setLogLevel(ci, Level.INFO.getName(), StandardCommandTest.class.getName());
+            assertTrue(rootHandler.isLoggable(rec), "Root handler should not have moved back to INFO");
+            assertFalse(logger.isLoggable(rec.getLevel()), "FINE should no longer be loggable in the logger");
+        }
+
+        @Test
+        public void testLogLevelNamespace() {
+            LogRecord rec = new LogRecord(Level.FINE, "Test");
+            //
+            // Move the log level for this class
+            cmds.setLogLevel(ci, Level.FINE.getName(), "com.oracle.labs.mlrg");
+            assertTrue(logger.isLoggable(rec.getLevel()), "Logger should be able to log FINE now");
+            assertTrue(rootHandler.isLoggable(rec), "Handlers should be able to log fine");
+
+            //
+            // Move the log level back up. This should only move the logger and not the handler
+            cmds.setLogLevel(ci, Level.INFO.getName(), "com.oracle.labs.mlrg");
+            assertTrue(rootHandler.isLoggable(rec), "Root handler should not have moved back to INFO");
+            assertFalse(logger.isLoggable(rec.getLevel()), "FINE should no longer be loggable in the logger");
+        }
+
+        @Test
+        public void testLogLevelHandler() {
+            LogRecord rec = new LogRecord(Level.FINE, "Test");
+
+            cmds.setLogLevel(ci, Level.FINER.getName(), "");
+            assertTrue(rootHandler.isLoggable(rec), "FINE should now be loggable in the handler");
+        }
+    }
+}

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/command/StandardCommandTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/command/StandardCommandTest.java
@@ -3,7 +3,6 @@ package com.oracle.labs.mlrg.olcut.command;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import jdk.jfr.internal.LogLevel;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
This PR adds a command to the standard set of commands available in the command shell that allows you to modify the log level either for a specific target logger or for the log handlers. I've also added a stub of a unit test for the standard commands that currently only tests the log level command. If any standard commands are touched, we should add tests for them as we go.