### PR TITLE
Fix for ConfigurationData.structuralEquals tests on Windows

### DIFF
--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: OLCUT CI (macOS x86_64, OpenJDK 8, 11, latest)
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # test against supported LTS versions and latest
+        java: [ 8, 11, 16 ]
+    name: OLCUT - macOS OpenJDK ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup OpenJDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -1,8 +1,7 @@
-  
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: OLCUT CI, OpenJDK 8, 11 and latest - Ubuntu x86_64
+name: OLCUT CI (Ubuntu x86_64, OpenJDK 8, 11, latest)
 
 on:
   push:
@@ -17,7 +16,7 @@ jobs:
       matrix:
         # test against supported LTS versions and latest
         java: [ 8, 11, 16 ]
-    name: OLCUT - OpenJDK ${{ matrix.java }}
+    name: OLCUT - Ubuntu OpenJDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup OpenJDK

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: OLCUT CI (Windows x86_64, OpenJDK 8, 11, latest)
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        # test against supported LTS versions and latest
+        java: [ 8, 11, 16 ]
+    name: OLCUT - Windows OpenJDK ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup OpenJDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/ConfigurationDataTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/config/ConfigurationDataTest.java
@@ -42,9 +42,14 @@ public class ConfigurationDataTest {
 
     @Test
     public void structuralEqualsAllConfig() {
+        // We're going to round-trip this through instantiation and importing once to normalize all the
+        // values. Otherwise Windows produces paths rooted at "C:\" while posix platforms use "/".
         final String aName = "all-config";
         ConfigurationManager cm = new ConfigurationManager("allConfig.xml");
         AllFieldsConfigurable ac = (AllFieldsConfigurable) cm.lookup(aName);
+        cm.close();
+        cm = new ConfigurationManager();
+        cm.importConfigurable(ac);
         List<ConfigurationData> a = cm.getComponentNames().stream()
                 .map(cm::getConfigurationData)
                 .filter(Optional::isPresent)
@@ -54,7 +59,6 @@ public class ConfigurationDataTest {
         cm.close();
         cm = new ConfigurationManager();
         final String bName = cm.importConfigurable(ac);
-
         List<ConfigurationData> b = cm.getComponentNames().stream()
                 .map(cm::getConfigurationData)
                 .filter(Optional::isPresent)

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/util/StreamUtilTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/util/StreamUtilTest.java
@@ -52,7 +52,7 @@ public class StreamUtilTest {
 
     @Test
     public void testBoundedParallelism() throws ExecutionException, InterruptedException {
-        ForkJoinPool fjp = new ForkJoinPool(2);
+        ForkJoinPool fjp = new ForkJoinPool(1);
 
         AtomicInteger unboundedCounter = new AtomicInteger();
         Stream<Integer> unbounded = wrapStream(StreamUtil.boundParallelism(arrayFactory(10000).parallel()),unboundedCounter);
@@ -64,7 +64,7 @@ public class StreamUtilTest {
 
         logger.finer("Unbounded = " + unboundedCounter.get() + ", bounded = " + boundedCounter.get());
         assertNotEquals(boundedCounter.get(), unboundedCounter.get(), "Parallelism wasn't bounded");
-        assertEquals(2 << 2, boundedCounter.get(), "Parallelism wasn't bounded");
+        assertEquals(1 << 2, boundedCounter.get(), "Parallelism wasn't bounded");
     }
 
     public static Stream<Integer> arrayFactory(int size) {

--- a/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/util/StreamUtilTest.java
+++ b/olcut-core/src/test/java/com/oracle/labs/mlrg/olcut/util/StreamUtilTest.java
@@ -32,6 +32,7 @@ package com.oracle.labs.mlrg.olcut.util;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Spliterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
@@ -52,7 +53,16 @@ public class StreamUtilTest {
 
     @Test
     public void testBoundedParallelism() throws ExecutionException, InterruptedException {
-        ForkJoinPool fjp = new ForkJoinPool(1);
+        // This hack is to ensure that tests pass on Github Actions, which uses weird VMs for macOS that confuse the
+        // parallelism checks.
+        int parallelismLevel;
+        String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
+        if (os.contains("mac") || os.contains("darwin")) {
+            parallelismLevel = 1;
+        } else {
+            parallelismLevel = 2;
+        }
+        ForkJoinPool fjp = new ForkJoinPool(parallelismLevel);
 
         AtomicInteger unboundedCounter = new AtomicInteger();
         Stream<Integer> unbounded = wrapStream(StreamUtil.boundParallelism(arrayFactory(10000).parallel()),unboundedCounter);
@@ -64,7 +74,7 @@ public class StreamUtilTest {
 
         logger.finer("Unbounded = " + unboundedCounter.get() + ", bounded = " + boundedCounter.get());
         assertNotEquals(boundedCounter.get(), unboundedCounter.get(), "Parallelism wasn't bounded");
-        assertEquals(1 << 2, boundedCounter.get(), "Parallelism wasn't bounded");
+        assertEquals(parallelismLevel << 2, boundedCounter.get(), "Parallelism wasn't bounded");
     }
 
     public static Stream<Integer> arrayFactory(int size) {


### PR DESCRIPTION
Adds Windows & macOS CIs via Github Actions. Fixes the test issue in ConfigurationData.structuralEquals by roundtripping it through instantiation once. This negates some of the benefit of the test (as it normalizes URLs, booleans and floating point values), but Windows roots paths at `C:\` and posix roots them at `\`, and those are definitely not something which we should consider equal.