### PR TITLE
Bumping to the latest versions of jackson, jline3, junit and protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <edn.version>0.7.1</edn.version>
-        <jackson.version>2.12.5</jackson.version>
-        <jline.version>3.20.0</jline.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jline.version>3.21.0</jline.version>
         <junit.version>5.7.1</junit.version>
-        <protobuf.version>3.17.3</protobuf.version>
+        <protobuf.version>3.19.4</protobuf.version>
     </properties>
     <modules>
         <module>olcut-core</module>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <edn.version>0.7.1</edn.version>
         <jackson.version>2.13.2</jackson.version>
         <jline.version>3.21.0</jline.version>
-        <junit.version>5.7.1</junit.version>
+        <junit.version>5.8.2</junit.version>
         <protobuf.version>3.19.4</protobuf.version>
     </properties>
     <modules>


### PR DESCRIPTION
Jackson 2.12 has a stack overflow issue in it's deserializer, and I bumped the rest of the versions to latest as well.