### PR TITLE
Bumping databind to a version without security issues

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,4 +1,4 @@
-jline 3.20.0
+jline 3.21.0
 
 Copyright (c) 2002-2018, the original author or authors.
 All rights reserved.
@@ -35,7 +35,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
-jackson-core, jackson-databind 2.12.5
+jackson-core, jackson-databind 2.13.2, 2.13.2.2
 
 
                                  Apache License
@@ -240,7 +240,7 @@ jackson-core, jackson-databind 2.12.5
    See the License for the specific language governing permissions and
    limitations under the License.
 
-junit 5.7.1
+junit 5.8.2
 
 Copyright 2015-2021 the original author or authors.
 
@@ -576,7 +576,7 @@ this Agreement will bring a legal action under this Agreement more than
 one year after the cause of action arose. Each party waives its rights to
 a jury trial in any resulting litigation.
 
-protobuf-java 3.17.3
+protobuf-java 3.19.4
 
 Copyright 2008 Google Inc.  All rights reserved.
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <edn.version>0.7.1</edn.version>
         <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
         <jline.version>3.21.0</jline.version>
         <junit.version>5.8.2</junit.version>
         <protobuf.version>3.19.4</protobuf.version>
@@ -144,7 +145,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>us.bpsm</groupId>


### PR DESCRIPTION
Split databind out to its own version to fix an issue in just jackson-databind, but we should be very careful to make sure these line up.