### PR TITLE
Updating Github templates and CI

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Bug reports
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behaviour, including a description of how you're using the library preferably with pseudocode or a code snippet.
+
+**Expected behaviour**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+**System information:**
+
+ - OLCUT Version: [e.g., 5.3.0]
+ - OS: [e.g., Windows/macOS/Linux]
+ - Java Version: [e.g., 8, 11, 17 etc]
+ - JDK Vendor: [e.g., Oracle, OpenJDK etc]
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/workflows/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/workflows/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/maven-macos.yml
+++ b/.github/workflows/maven-macos.yml
@@ -5,9 +5,9 @@ name: OLCUT CI (macOS x86_64, OpenJDK 8, 11, 17)
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/maven-ubuntu.yml
+++ b/.github/workflows/maven-ubuntu.yml
@@ -5,9 +5,9 @@ name: OLCUT CI (Ubuntu x86_64, OpenJDK 8, 11, 17)
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/maven-windows.yml
+++ b/.github/workflows/maven-windows.yml
@@ -5,9 +5,9 @@ name: OLCUT CI (Windows x86_64, OpenJDK 8, 11, 17)
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/pull_request_template.md
+++ b/.github/workflows/pull_request_template.md
@@ -1,0 +1,10 @@
+### Description
+< Insert text describing your change >
+
+### Motivation
+< Why is this change necessary? Is it a bug fix or new feature? >
+
+< Please link any relevant issues or PRs >
+
+### Paper reference
+< If this PR introduces a new algorithm or ML feature, please cite the original paper >


### PR DESCRIPTION
Adds simple issue & PR templates, and updates the CI so it doesn't point at the deleted `develop` branch.