### PR TITLE
Fixing an NPE when the component is missing its parent

### DIFF
--- a/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonLoader.java
+++ b/olcut-config-json/src/main/java/com/oracle/labs/mlrg/olcut/config/json/JsonLoader.java
@@ -248,10 +248,10 @@ public class JsonLoader implements ConfigLoader {
             // just in case.
             ConfigurationData spd = rpdMap.get(override);
             if (spd == null) {
-                spd = existingRPD.get(override);
-                if (spd == null) {
-                    throw new ConfigLoaderException("Override for undefined component: "
-                            + override + ", with name " + curComponent);
+                if (existingRPD == null || !existingRPD.containsKey(override)) {
+                    throw new ConfigLoaderException("Failed to find base component '"+override+"' inherited from '"+curComponent+"'.");
+                } else {
+                    spd = existingRPD.get(override);
                 }
             }
             if (curType != null && !curType.equals(spd.getClassName())) {

--- a/olcut-config-json/src/test/java/com/oracle/labs/mlrg/olcut/config/json/test/OverrideTest.java
+++ b/olcut-config-json/src/test/java/com/oracle/labs/mlrg/olcut/config/json/test/OverrideTest.java
@@ -29,11 +29,14 @@
 package com.oracle.labs.mlrg.olcut.config.json.test;
 
 import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
+import com.oracle.labs.mlrg.olcut.config.io.ConfigLoaderException;
 import com.oracle.labs.mlrg.olcut.config.json.JsonConfigFactory;
 import com.oracle.labs.mlrg.olcut.test.config.StringConfigurable;
 import com.oracle.labs.mlrg.olcut.test.config.StringleConfigurable;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -98,5 +101,14 @@ public class OverrideTest {
         assertEquals("b", sc2.two);
         assertEquals("d", sc2.three);
         assertEquals("e", sc2.four);
+    }
+
+    @Test
+    public void overrideIncorrectName() {
+        Assertions.assertThrows(ConfigLoaderException.class,
+                () -> {
+                    ConfigurationManager cm = new ConfigurationManager(createModuleResourceString(this.getClass(),
+                            "overrideIncorrect.json"));
+                });
     }
 }

--- a/olcut-config-json/src/test/resources/com/oracle/labs/mlrg/olcut/config/json/test/overrideIncorrect.json
+++ b/olcut-config-json/src/test/resources/com/oracle/labs/mlrg/olcut/config/json/test/overrideIncorrect.json
@@ -1,0 +1,21 @@
+{
+  "config": {
+    "global-properties": {},
+    "components": [
+      {
+        "name": "a",
+        "type": "com.oracle.labs.mlrg.olcut.test.config.StringConfigurable",
+        "properties": {
+          "one": "a",
+          "two": "b",
+          "three": "c"
+        }
+      },
+      {
+        "name": "bErr",
+        "inherit": "aErr",
+        "properties": {}
+      }
+    ]
+  }
+}

--- a/olcut-config-protobuf/src/main/java/com/oracle/labs/mlrg/olcut/config/protobuf/ProtoLoader.java
+++ b/olcut-config-protobuf/src/main/java/com/oracle/labs/mlrg/olcut/config/protobuf/ProtoLoader.java
@@ -248,10 +248,10 @@ public final class ProtoLoader implements ConfigLoader {
             // just in case.
             ConfigurationData spd = rpdMap.get(override);
             if (spd == null) {
-                spd = existingRPD.get(override);
-                if (spd == null) {
-                    throw new ConfigLoaderException("Override for undefined component: "
-                            + override + ", with name " + name);
+                if (existingRPD == null || !existingRPD.containsKey(override)) {
+                    throw new ConfigLoaderException("Failed to find base component '"+override+"' inherited from '"+name+"'.");
+                } else {
+                    spd = existingRPD.get(override);
                 }
             }
             if (!type.isEmpty() && !type.equals(spd.getClassName())) {

--- a/olcut-config-protobuf/src/test/java/com/oracle/labs/mlrg/olcut/config/protobuf/test/OverrideTest.java
+++ b/olcut-config-protobuf/src/test/java/com/oracle/labs/mlrg/olcut/config/protobuf/test/OverrideTest.java
@@ -29,9 +29,12 @@
 package com.oracle.labs.mlrg.olcut.config.protobuf.test;
 
 import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
+import com.oracle.labs.mlrg.olcut.config.io.ConfigLoaderException;
 import com.oracle.labs.mlrg.olcut.config.protobuf.ProtoConfigFactory;
+import com.oracle.labs.mlrg.olcut.config.protobuf.ProtoTxtConfigFactory;
 import com.oracle.labs.mlrg.olcut.test.config.StringConfigurable;
 import com.oracle.labs.mlrg.olcut.test.config.StringleConfigurable;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -49,6 +52,7 @@ public class OverrideTest {
     @BeforeAll
     public static void setUpClass() throws Exception {
         ConfigurationManager.addFileFormatFactory(new ProtoConfigFactory());
+        ConfigurationManager.addFileFormatFactory(new ProtoTxtConfigFactory());
     }
 
     @Test
@@ -98,5 +102,14 @@ public class OverrideTest {
         assertEquals("b", sc2.two);
         assertEquals("d", sc2.three);
         assertEquals("e", sc2.four);
+    }
+
+    @Test
+    public void overrideIncorrectName() {
+        Assertions.assertThrows(ConfigLoaderException.class,
+                () -> {
+                    ConfigurationManager cm = new ConfigurationManager(createModuleResourceString(this.getClass(),
+                            "overrideIncorrect.pbtxt"));
+                });
     }
 }

--- a/olcut-config-protobuf/src/test/resources/com/oracle/labs/mlrg/olcut/config/protobuf/test/overrideIncorrect.pbtxt
+++ b/olcut-config-protobuf/src/test/resources/com/oracle/labs/mlrg/olcut/config/protobuf/test/overrideIncorrect.pbtxt
@@ -1,0 +1,20 @@
+components {
+  name: "a"
+  type: "com.oracle.labs.mlrg.olcut.test.config.StringConfigurable"
+  properties {
+    key: "one"
+    value: "a"
+  }
+  properties {
+    key: "second"
+    value: "b"
+  }
+  properties {
+    key: "three"
+    value: "c"
+  }
+}
+components {
+  name: "bErr",
+  override: "aErr"
+}

--- a/olcut-core-test/src/test/java/com/oracle/labs/mlrg/olcut/test/config_tests/OverrideTest.java
+++ b/olcut-core-test/src/test/java/com/oracle/labs/mlrg/olcut/test/config_tests/OverrideTest.java
@@ -31,6 +31,7 @@ package com.oracle.labs.mlrg.olcut.test.config_tests;
 import java.io.IOException;
 
 import com.oracle.labs.mlrg.olcut.config.ConfigurationManager;
+import com.oracle.labs.mlrg.olcut.config.io.ConfigLoaderException;
 import com.oracle.labs.mlrg.olcut.test.config.StringConfigurable;
 import com.oracle.labs.mlrg.olcut.test.config.StringleConfigurable;
 import org.junit.jupiter.api.Assertions;
@@ -43,10 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  */
 public class OverrideTest {
-
-    public OverrideTest() {
-    }
-
 
     @Test
     public void overrideWithSameType() throws IOException {
@@ -95,5 +92,14 @@ public class OverrideTest {
         Assertions.assertEquals("b", sc2.two);
         Assertions.assertEquals("d", sc2.three);
         Assertions.assertEquals("e", sc2.four);
+    }
+
+    @Test
+    public void overrideIncorrectName() {
+        Assertions.assertThrows(ConfigLoaderException.class,
+                () -> {
+                    ConfigurationManager cm = new ConfigurationManager(createModuleResourceString(this.getClass(),
+                            "overrideIncorrect.xml"));
+                });
     }
 }

--- a/olcut-core-test/src/test/resources/com/oracle/labs/mlrg/olcut/test/config_tests/overrideIncorrect.xml
+++ b/olcut-core-test/src/test/resources/com/oracle/labs/mlrg/olcut/test/config_tests/overrideIncorrect.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<config>
+
+    <component name="a" type="com.oracle.labs.mlrg.olcut.test.config.StringConfigurable">
+        <property name="one" value="a"/>
+        <property name="two" value="b"/>
+        <property name="three" value="c"/>
+    </component>
+
+    <component name="bErr" inherit="aErr"/>
+</config>

--- a/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/xml/SAXLoader.java
+++ b/olcut-core/src/main/java/com/oracle/labs/mlrg/olcut/config/xml/SAXLoader.java
@@ -264,10 +264,10 @@ public class SAXLoader implements ConfigLoader {
                         // just in case.
                         ConfigurationData spd = rpdMap.get(override);
                         if (spd == null) {
-                            spd = existingRPD.get(override);
-                            if (spd == null) {
-                                throw new SAXParseException("Override for undefined component: "
-                                        + override, locator);
+                            if (existingRPD == null || !existingRPD.containsKey(override)) {
+                                throw new SAXParseException("Failed to find base component '"+override+"' inherited from '"+curComponent+"'.", locator);
+                            } else {
+                                spd = existingRPD.get(override);
                             }
                         }
                         if (curType != null && !curType.equals(spd.getClassName())) {


### PR DESCRIPTION
@JackSullivan found an issue where OLCUT throws an NPE in xml, json and pb when a component is inheriting its properties, but the component it inherits from isn't present in the file. Config files which exhibit this issue are invalid, but the NPE doesn't tell you what happened. This patch changes it so it throws `ConfigLoaderException` with a useful error message.